### PR TITLE
Add Lua interface for ComfyUI nodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"
 
 [workspace.dependencies]
 anyhow = "1.0"
+convert_case = "0.6.0"
 futures-timer = { version = "3.0", features = ["wasm-bindgen"] }
 indexmap = { version = "2", features = ["serde"] }
 reqwest = { version = "0.12", features = ["json", "multipart"] }

--- a/crates/rucomfyui/generate_nodes/Cargo.toml
+++ b/crates/rucomfyui/generate_nodes/Cargo.toml
@@ -18,4 +18,4 @@ quote = "1.0.37"
 prettyplease = "0.2.22"
 syn = "2.0.77"
 proc-macro2 = "1.0.86"
-convert_case = "0.6.0"
+convert_case = { workspace = true }

--- a/crates/rucomfyui_mlua/Cargo.toml
+++ b/crates/rucomfyui_mlua/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["api-bindings", "multimedia::images"]
 [dependencies]
 rucomfyui = { path = "../rucomfyui", default-features = false }
 mlua = { version = "0.10", features = ["lua54", "vendored", "async", "send", "serialize"] }
+convert_case = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/rucomfyui_mlua/Cargo.toml
+++ b/crates/rucomfyui_mlua/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "rucomfyui_mlua"
+version = "0.1.0"
+edition = "2021"
+description = "Lua bindings for rucomfyui - a fluent ComfyUI workflow builder"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/philpax/rucomfyui"
+keywords = ["comfyui", "lua", "mlua", "stable-diffusion"]
+categories = ["api-bindings", "multimedia::images"]
+
+[dependencies]
+rucomfyui = { path = "../rucomfyui", default-features = false }
+mlua = { version = "0.10", features = ["lua54", "vendored", "async", "send", "serialize"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rucomfyui_mlua/Cargo.toml
+++ b/crates/rucomfyui_mlua/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["api-bindings", "multimedia::images"]
 rucomfyui = { path = "../rucomfyui", default-features = false }
 mlua = { version = "0.10", features = ["lua54", "vendored", "async", "send", "serialize"] }
 convert_case = { workspace = true }
-serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/rucomfyui_mlua/Cargo.toml
+++ b/crates/rucomfyui_mlua/Cargo.toml
@@ -15,4 +15,5 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+anyhow = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rucomfyui_mlua/examples/run_script.rs
+++ b/crates/rucomfyui_mlua/examples/run_script.rs
@@ -1,0 +1,72 @@
+//! Run a Lua workflow script against a ComfyUI server.
+//!
+//! Usage: run_script <url> [script] [prompt]
+//!
+//! Arguments:
+//!   url     - ComfyUI server URL (e.g., http://127.0.0.1:8188)
+//!   script  - Path to Lua script (default: examples/workflow.lua)
+//!   prompt  - Text prompt to pass to the script (optional)
+
+use anyhow::Context;
+use mlua::Lua;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+
+    // Parse arguments
+    let url = args.get(1).context("Usage: run_script <url> [script] [prompt]")?;
+    let script_path = args
+        .get(2)
+        .map(|s| s.as_str())
+        .unwrap_or("crates/rucomfyui_mlua/examples/workflow.lua");
+    let prompt = args.get(3);
+
+    // Read the script
+    let script = std::fs::read_to_string(script_path)
+        .with_context(|| format!("Failed to read script: {}", script_path))?;
+
+    // Create Lua state
+    let lua = Lua::new();
+
+    // Set up the rucomfyui module
+    let config = rucomfyui_mlua::IntegrationConfig::all();
+    let comfy = rucomfyui_mlua::module(&lua, &config)?;
+    lua.globals().set("comfy", comfy)?;
+
+    // Create and set up the client
+    let client = rucomfyui_mlua::create_client_userdata(
+        &lua,
+        rucomfyui::Client::new(url),
+        rucomfyui_mlua::ClientConfig::all(),
+    )?;
+    lua.globals().set("client", client)?;
+
+    // Set the prompt if provided
+    if let Some(prompt) = prompt {
+        lua.globals().set("prompt", prompt.as_str())?;
+    }
+
+    // Run the script
+    println!("Running script: {}", script_path);
+    if let Some(prompt) = prompt {
+        println!("Prompt: {}", prompt);
+    }
+
+    let images: Vec<mlua::String> = lua
+        .load(&script)
+        .set_name(script_path)
+        .eval_async()
+        .await?;
+
+    // Save the images
+    for (idx, image) in images.iter().enumerate() {
+        let filename = format!("output_{}.png", idx);
+        std::fs::write(&filename, image.as_bytes())?;
+        println!("Saved: {}", filename);
+    }
+
+    println!("Done! Generated {} image(s)", images.len());
+
+    Ok(())
+}

--- a/crates/rucomfyui_mlua/examples/workflow.lua
+++ b/crates/rucomfyui_mlua/examples/workflow.lua
@@ -1,0 +1,39 @@
+-- Example workflow script for rucomfyui_mlua
+-- This script generates an image using Stable Diffusion XL
+--
+-- The following globals are provided by the runner:
+--   comfy: the rucomfyui module
+--   client: a connected ComfyUI client
+--   prompt: the text prompt to use (optional, defaults to "a cat sleeping on a red chair")
+
+local prompt = prompt or "a cat sleeping on a red chair"
+
+-- Get object info and create a graph
+local object_info = client:get_object_info()
+local g = comfy.graph(object_info)
+
+-- Build the workflow
+local c = g:CheckpointLoaderSimple("sd_xl_base_1.0.safetensors")
+local preview = g:PreviewImage(
+    g:VAEDecode {
+        vae = c.vae,
+        samples = g:KSampler {
+            model = c.model,
+            seed = 0,
+            steps = 20,
+            cfg = 8.0,
+            sampler_name = "euler",
+            scheduler = "normal",
+            positive = g:CLIPTextEncode { text = prompt, clip = c.clip },
+            negative = g:CLIPTextEncode { text = "text, watermark, blurry", clip = c.clip },
+            latent_image = g:EmptyLatentImage { width = 1024, height = 1024, batch_size = 1 },
+            denoise = 1.0
+        }
+    }
+)
+
+-- Queue the workflow and wait for results
+local result = client:easy_queue(g)
+
+-- Return the images from the preview node
+return result[preview].images

--- a/crates/rucomfyui_mlua/src/client.rs
+++ b/crates/rucomfyui_mlua/src/client.rs
@@ -198,8 +198,7 @@ impl LuaUserData for Client {
         methods.add_async_method("get_models", |lua, this, category: String| async move {
             this.check_allowed("get_models", this.config.get_models)?;
             let cat: rucomfyui::models::ModelCategory =
-                serde_json::from_value(serde_json::Value::String(category))
-                    .map_err(mlua::Error::external)?;
+                lua.from_value(LuaValue::String(lua.create_string(&category)?))?;
             let models = to_lua_result(this.inner.get_models(cat).await)?;
             lua.to_value(&models)
         });

--- a/crates/rucomfyui_mlua/src/client.rs
+++ b/crates/rucomfyui_mlua/src/client.rs
@@ -48,15 +48,12 @@ impl LuaUserData for Client {
     fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
         // ==================== Object Info ====================
 
-        // Get object info for all nodes.
-        // Returns a table that can be passed to `graph()`.
         methods.add_async_method("get_object_info", |lua, this, ()| async move {
             this.check_allowed("get_object_info", this.config.get_object_info)?;
             let object_info = to_lua_result(this.inner.get_object_info().await)?;
             lua.to_value(&object_info)
         });
 
-        // Get object info for a specific node by name.
         methods.add_async_method("get_object_for_name", |lua, this, name: String| async move {
             this.check_allowed("get_object_for_name", this.config.get_object_for_name)?;
             let object = to_lua_result(this.inner.get_object_for_name(&name).await)?;
@@ -65,8 +62,6 @@ impl LuaUserData for Client {
 
         // ==================== Queue Operations ====================
 
-        // Queue a workflow for execution.
-        // Takes a Graph and returns queue result with prompt_id.
         methods.add_async_method("queue", |lua, this, graph: LuaAnyUserData| async move {
             this.check_allowed("queue", this.config.queue)?;
             let graph_ref = graph.borrow::<Graph>()?;
@@ -74,16 +69,10 @@ impl LuaUserData for Client {
             drop(graph_ref);
 
             let result = to_lua_result(this.inner.queue(&workflow).await)?;
-
-            let table = lua.create_table()?;
-            table.set("prompt_id", result.prompt_id)?;
-            table.set("number", result.number)?;
-            table.set("node_errors", lua.to_value(&result.node_errors)?)?;
-            Ok(table)
+            lua.to_value(&result)
         });
 
-        // Queue a workflow and wait for results.
-        // Returns a table mapping node outputs to their results.
+        // easy_queue needs manual handling for images (bytes) and custom metatable
         methods.add_async_method("easy_queue", |lua, this, graph: LuaAnyUserData| async move {
             this.check_allowed("easy_queue", this.config.easy_queue)?;
             let graph_ref = graph.borrow::<Graph>()?;
@@ -92,7 +81,6 @@ impl LuaUserData for Client {
 
             let result = to_lua_result(this.inner.easy_queue(&workflow).await)?;
 
-            // Convert to Lua table
             let output_table = lua.create_table()?;
 
             for (node_id, node_output) in result {
@@ -112,7 +100,6 @@ impl LuaUserData for Client {
                 }
                 node_table.set("texts", texts_table)?;
 
-                // Use node_id as key (can be indexed by NodeOutput)
                 output_table.set(node_id.0, node_table)?;
             }
 
@@ -122,7 +109,6 @@ impl LuaUserData for Client {
                 "__index",
                 lua.create_function(
                     |_lua, (table, key): (LuaTable, LuaValue)| -> LuaResult<LuaValue> {
-                        // If key is a NodeOutput, get its node_id
                         if let LuaValue::UserData(ud) = &key {
                             if let Ok(output) = ud.borrow::<NodeOutput>() {
                                 return table.raw_get(output.node_id.0);
@@ -133,7 +119,6 @@ impl LuaUserData for Client {
                                 return table.raw_get(outputs.node_id.0);
                             }
                         }
-                        // Fall back to raw get
                         table.raw_get(key)
                     },
                 )?,
@@ -143,52 +128,18 @@ impl LuaUserData for Client {
             Ok(output_table)
         });
 
-        // Get the current queue status.
         methods.add_async_method("get_queue", |lua, this, ()| async move {
             this.check_allowed("get_queue", this.config.get_queue)?;
             let queue = to_lua_result(this.inner.get_queue().await)?;
-
-            let table = lua.create_table()?;
-
-            // Running entries
-            let running = lua.create_table()?;
-            for (i, entry) in queue.running.into_iter().enumerate() {
-                let entry_table = lua.create_table()?;
-                entry_table.set("number", entry.number)?;
-                entry_table.set("prompt_id", entry.prompt_id)?;
-                entry_table.set("prompt", lua.to_value(&entry.prompt)?)?;
-                entry_table.set("extra_data", lua.to_value(&entry.extra_data)?)?;
-                let outputs: Vec<u32> = entry.outputs_to_execute.iter().map(|id| id.0).collect();
-                entry_table.set("outputs_to_execute", outputs)?;
-                running.set(i + 1, entry_table)?;
-            }
-            table.set("running", running)?;
-
-            // Pending entries
-            let pending = lua.create_table()?;
-            for (i, entry) in queue.pending.into_iter().enumerate() {
-                let entry_table = lua.create_table()?;
-                entry_table.set("number", entry.number)?;
-                entry_table.set("prompt_id", entry.prompt_id)?;
-                entry_table.set("prompt", lua.to_value(&entry.prompt)?)?;
-                entry_table.set("extra_data", lua.to_value(&entry.extra_data)?)?;
-                let outputs: Vec<u32> = entry.outputs_to_execute.iter().map(|id| id.0).collect();
-                entry_table.set("outputs_to_execute", outputs)?;
-                pending.set(i + 1, entry_table)?;
-            }
-            table.set("pending", pending)?;
-
-            Ok(table)
+            lua.to_value(&queue)
         });
 
-        // Interrupt the current workflow.
         methods.add_async_method("interrupt", |_lua, this, ()| async move {
             this.check_allowed("interrupt", this.config.interrupt)?;
             to_lua_result(this.inner.interrupt().await)?;
             Ok(())
         });
 
-        // Delete workflows from the queue by prompt IDs.
         methods.add_async_method(
             "delete_from_queue",
             |_lua, this, prompt_ids: Vec<String>| async move {
@@ -198,7 +149,6 @@ impl LuaUserData for Client {
             },
         );
 
-        // Clear the entire queue.
         methods.add_async_method("clear_queue", |_lua, this, ()| async move {
             this.check_allowed("clear_queue", this.config.clear_queue)?;
             to_lua_result(this.inner.clear_queue().await)?;
@@ -207,14 +157,12 @@ impl LuaUserData for Client {
 
         // ==================== History Operations ====================
 
-        // Get history with a maximum number of items.
         methods.add_async_method("get_history", |lua, this, max_items: u32| async move {
             this.check_allowed("get_history", this.config.get_history)?;
             let history = to_lua_result(this.inner.get_history(max_items).await)?;
             lua.to_value(&history)
         });
 
-        // Get history for a specific prompt.
         methods.add_async_method(
             "get_history_for_prompt",
             |lua, this, prompt_id: String| async move {
@@ -224,7 +172,6 @@ impl LuaUserData for Client {
             },
         );
 
-        // Delete entries from history by prompt IDs.
         methods.add_async_method(
             "delete_from_history",
             |_lua, this, prompt_ids: Vec<String>| async move {
@@ -234,7 +181,6 @@ impl LuaUserData for Client {
             },
         );
 
-        // Clear all history.
         methods.add_async_method("clear_history", |_lua, this, ()| async move {
             this.check_allowed("clear_history", this.config.clear_history)?;
             to_lua_result(this.inner.clear_history().await)?;
@@ -243,76 +189,29 @@ impl LuaUserData for Client {
 
         // ==================== Model Operations ====================
 
-        // Get all model categories.
         methods.add_async_method("get_model_categories", |lua, this, ()| async move {
             this.check_allowed("get_model_categories", this.config.get_model_categories)?;
             let categories = to_lua_result(this.inner.get_model_categories().await)?;
-            let table = lua.create_table()?;
-            for (i, cat) in categories.into_iter().enumerate() {
-                table.set(i + 1, cat.to_string())?;
-            }
-            Ok(table)
+            lua.to_value(&categories)
         });
 
-        // Get models in a category.
         methods.add_async_method("get_models", |lua, this, category: String| async move {
             this.check_allowed("get_models", this.config.get_models)?;
-            // Parse the category string
             let cat: rucomfyui::models::ModelCategory =
                 serde_json::from_value(serde_json::Value::String(category))
                     .map_err(mlua::Error::external)?;
             let models = to_lua_result(this.inner.get_models(cat).await)?;
-            let table = lua.create_table()?;
-            for (i, model) in models.into_iter().enumerate() {
-                table.set(i + 1, model)?;
-            }
-            Ok(table)
+            lua.to_value(&models)
         });
 
         // ==================== System Operations ====================
 
-        // Get system statistics.
         methods.add_async_method("system_stats", |lua, this, ()| async move {
             this.check_allowed("system_stats", this.config.system_stats)?;
             let stats = to_lua_result(this.inner.system_stats().await)?;
-
-            let table = lua.create_table()?;
-
-            // System info
-            let system = lua.create_table()?;
-            system.set("os", stats.system.os)?;
-            system.set("ram_total", stats.system.ram_total)?;
-            system.set("ram_free", stats.system.ram_free)?;
-            system.set("comfyui_version", stats.system.comfyui_version)?;
-            system.set("python_version", stats.system.python_version)?;
-            system.set("pytorch_version", stats.system.pytorch_version)?;
-            system.set("embedded_python", stats.system.embedded_python)?;
-            let argv = lua.create_table()?;
-            for (i, arg) in stats.system.argv.into_iter().enumerate() {
-                argv.set(i + 1, arg)?;
-            }
-            system.set("argv", argv)?;
-            table.set("system", system)?;
-
-            // Devices
-            let devices = lua.create_table()?;
-            for (i, device) in stats.devices.into_iter().enumerate() {
-                let dev = lua.create_table()?;
-                dev.set("name", device.name)?;
-                dev.set("type", device.device_type)?;
-                dev.set("index", device.index)?;
-                dev.set("vram_total", device.vram_total)?;
-                dev.set("vram_free", device.vram_free)?;
-                dev.set("torch_vram_total", device.torch_vram_total)?;
-                dev.set("torch_vram_free", device.torch_vram_free)?;
-                devices.set(i + 1, dev)?;
-            }
-            table.set("devices", devices)?;
-
-            Ok(table)
+            lua.to_value(&stats)
         });
 
-        // Free memory and/or unload models.
         methods.add_async_method(
             "free",
             |_lua, this, (unload_models, free_memory): (bool, bool)| async move {
@@ -324,8 +223,6 @@ impl LuaUserData for Client {
 
         // ==================== Upload Operations ====================
 
-        // Upload an image to ComfyUI.
-        // Takes filename and bytes (as a Lua string).
         methods.add_async_method(
             "upload",
             |lua, this, (filename, bytes): (String, LuaString)| async move {

--- a/crates/rucomfyui_mlua/src/client.rs
+++ b/crates/rucomfyui_mlua/src/client.rs
@@ -1,0 +1,298 @@
+//! ComfyUI client for Lua.
+
+use mlua::prelude::*;
+
+use crate::{error::to_lua_result, graph::Graph, node_output::NodeOutput};
+
+/// A ComfyUI client.
+///
+/// This wraps the rucomfyui Client and exposes its functionality to Lua.
+pub struct Client {
+    inner: rucomfyui::Client,
+}
+
+impl Client {
+    /// Create a new client.
+    pub fn new(_lua: &Lua, url: String) -> LuaResult<Self> {
+        Ok(Self {
+            inner: rucomfyui::Client::new(url),
+        })
+    }
+}
+
+impl LuaUserData for Client {
+    fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
+        // ==================== Object Info ====================
+
+        // Get object info for all nodes.
+        // Returns a table that can be passed to `graph()`.
+        methods.add_async_method("get_object_info", |lua, this, ()| async move {
+            let object_info = to_lua_result(this.inner.get_object_info().await)?;
+            lua.to_value(&object_info)
+        });
+
+        // Get object info for a specific node by name.
+        methods.add_async_method("get_object_for_name", |lua, this, name: String| async move {
+            let object = to_lua_result(this.inner.get_object_for_name(&name).await)?;
+            lua.to_value(&object)
+        });
+
+        // ==================== Queue Operations ====================
+
+        // Queue a workflow for execution.
+        // Takes a Graph and returns queue result with prompt_id.
+        methods.add_async_method("queue", |lua, this, graph: LuaAnyUserData| async move {
+            let graph_ref = graph.borrow::<Graph>()?;
+            let workflow = graph_ref.to_workflow();
+            drop(graph_ref);
+
+            let result = to_lua_result(this.inner.queue(&workflow).await)?;
+
+            let table = lua.create_table()?;
+            table.set("prompt_id", result.prompt_id)?;
+            table.set("number", result.number)?;
+            table.set("node_errors", lua.to_value(&result.node_errors)?)?;
+            Ok(table)
+        });
+
+        // Queue a workflow and wait for results.
+        // Returns a table mapping node outputs to their results.
+        methods.add_async_method("easy_queue", |lua, this, graph: LuaAnyUserData| async move {
+            let graph_ref = graph.borrow::<Graph>()?;
+            let workflow = graph_ref.to_workflow();
+            drop(graph_ref);
+
+            let result = to_lua_result(this.inner.easy_queue(&workflow).await)?;
+
+            // Convert to Lua table
+            let output_table = lua.create_table()?;
+
+            for (node_id, node_output) in result {
+                let node_table = lua.create_table()?;
+
+                // Images as byte strings
+                let images_table = lua.create_table()?;
+                for (i, image) in node_output.images.into_iter().enumerate() {
+                    images_table.set(i + 1, lua.create_string(&image)?)?;
+                }
+                node_table.set("images", images_table)?;
+
+                // Texts
+                let texts_table = lua.create_table()?;
+                for (i, text) in node_output.texts.into_iter().enumerate() {
+                    texts_table.set(i + 1, text)?;
+                }
+                node_table.set("texts", texts_table)?;
+
+                // Use node_id as key (can be indexed by NodeOutput)
+                output_table.set(node_id.0, node_table)?;
+            }
+
+            // Add a metatable to allow indexing by NodeOutput
+            let metatable = lua.create_table()?;
+            metatable.set(
+                "__index",
+                lua.create_function(
+                    |_lua, (table, key): (LuaTable, LuaValue)| -> LuaResult<LuaValue> {
+                        // If key is a NodeOutput, get its node_id
+                        if let LuaValue::UserData(ud) = &key {
+                            if let Ok(output) = ud.borrow::<NodeOutput>() {
+                                return table.raw_get(output.node_id.0);
+                            }
+                            if let Ok(outputs) =
+                                ud.borrow::<crate::node_output::NodeOutputs>()
+                            {
+                                return table.raw_get(outputs.node_id.0);
+                            }
+                        }
+                        // Fall back to raw get
+                        table.raw_get(key)
+                    },
+                )?,
+            )?;
+            output_table.set_metatable(Some(metatable));
+
+            Ok(output_table)
+        });
+
+        // Get the current queue status.
+        methods.add_async_method("get_queue", |lua, this, ()| async move {
+            let queue = to_lua_result(this.inner.get_queue().await)?;
+
+            let table = lua.create_table()?;
+
+            // Running entries
+            let running = lua.create_table()?;
+            for (i, entry) in queue.running.into_iter().enumerate() {
+                let entry_table = lua.create_table()?;
+                entry_table.set("number", entry.number)?;
+                entry_table.set("prompt_id", entry.prompt_id)?;
+                entry_table.set("prompt", lua.to_value(&entry.prompt)?)?;
+                entry_table.set("extra_data", lua.to_value(&entry.extra_data)?)?;
+                let outputs: Vec<u32> = entry.outputs_to_execute.iter().map(|id| id.0).collect();
+                entry_table.set("outputs_to_execute", outputs)?;
+                running.set(i + 1, entry_table)?;
+            }
+            table.set("running", running)?;
+
+            // Pending entries
+            let pending = lua.create_table()?;
+            for (i, entry) in queue.pending.into_iter().enumerate() {
+                let entry_table = lua.create_table()?;
+                entry_table.set("number", entry.number)?;
+                entry_table.set("prompt_id", entry.prompt_id)?;
+                entry_table.set("prompt", lua.to_value(&entry.prompt)?)?;
+                entry_table.set("extra_data", lua.to_value(&entry.extra_data)?)?;
+                let outputs: Vec<u32> = entry.outputs_to_execute.iter().map(|id| id.0).collect();
+                entry_table.set("outputs_to_execute", outputs)?;
+                pending.set(i + 1, entry_table)?;
+            }
+            table.set("pending", pending)?;
+
+            Ok(table)
+        });
+
+        // Interrupt the current workflow.
+        methods.add_async_method("interrupt", |_lua, this, ()| async move {
+            to_lua_result(this.inner.interrupt().await)?;
+            Ok(())
+        });
+
+        // Delete workflows from the queue by prompt IDs.
+        methods.add_async_method(
+            "delete_from_queue",
+            |_lua, this, prompt_ids: Vec<String>| async move {
+                to_lua_result(this.inner.delete_from_queue(prompt_ids).await)?;
+                Ok(())
+            },
+        );
+
+        // Clear the entire queue.
+        methods.add_async_method("clear_queue", |_lua, this, ()| async move {
+            to_lua_result(this.inner.clear_queue().await)?;
+            Ok(())
+        });
+
+        // ==================== History Operations ====================
+
+        // Get history with a maximum number of items.
+        methods.add_async_method("get_history", |lua, this, max_items: u32| async move {
+            let history = to_lua_result(this.inner.get_history(max_items).await)?;
+            lua.to_value(&history)
+        });
+
+        // Get history for a specific prompt.
+        methods.add_async_method(
+            "get_history_for_prompt",
+            |lua, this, prompt_id: String| async move {
+                let history = to_lua_result(this.inner.get_history_for_prompt(&prompt_id).await)?;
+                lua.to_value(&history)
+            },
+        );
+
+        // Delete entries from history by prompt IDs.
+        methods.add_async_method(
+            "delete_from_history",
+            |_lua, this, prompt_ids: Vec<String>| async move {
+                to_lua_result(this.inner.delete_from_history(prompt_ids).await)?;
+                Ok(())
+            },
+        );
+
+        // Clear all history.
+        methods.add_async_method("clear_history", |_lua, this, ()| async move {
+            to_lua_result(this.inner.clear_history().await)?;
+            Ok(())
+        });
+
+        // ==================== Model Operations ====================
+
+        // Get all model categories.
+        methods.add_async_method("get_model_categories", |lua, this, ()| async move {
+            let categories = to_lua_result(this.inner.get_model_categories().await)?;
+            let table = lua.create_table()?;
+            for (i, cat) in categories.into_iter().enumerate() {
+                table.set(i + 1, cat.to_string())?;
+            }
+            Ok(table)
+        });
+
+        // Get models in a category.
+        methods.add_async_method("get_models", |lua, this, category: String| async move {
+            // Parse the category string
+            let cat: rucomfyui::models::ModelCategory =
+                serde_json::from_value(serde_json::Value::String(category))
+                    .map_err(mlua::Error::external)?;
+            let models = to_lua_result(this.inner.get_models(cat).await)?;
+            let table = lua.create_table()?;
+            for (i, model) in models.into_iter().enumerate() {
+                table.set(i + 1, model)?;
+            }
+            Ok(table)
+        });
+
+        // ==================== System Operations ====================
+
+        // Get system statistics.
+        methods.add_async_method("system_stats", |lua, this, ()| async move {
+            let stats = to_lua_result(this.inner.system_stats().await)?;
+
+            let table = lua.create_table()?;
+
+            // System info
+            let system = lua.create_table()?;
+            system.set("os", stats.system.os)?;
+            system.set("ram_total", stats.system.ram_total)?;
+            system.set("ram_free", stats.system.ram_free)?;
+            system.set("comfyui_version", stats.system.comfyui_version)?;
+            system.set("python_version", stats.system.python_version)?;
+            system.set("pytorch_version", stats.system.pytorch_version)?;
+            system.set("embedded_python", stats.system.embedded_python)?;
+            let argv = lua.create_table()?;
+            for (i, arg) in stats.system.argv.into_iter().enumerate() {
+                argv.set(i + 1, arg)?;
+            }
+            system.set("argv", argv)?;
+            table.set("system", system)?;
+
+            // Devices
+            let devices = lua.create_table()?;
+            for (i, device) in stats.devices.into_iter().enumerate() {
+                let dev = lua.create_table()?;
+                dev.set("name", device.name)?;
+                dev.set("type", device.device_type)?;
+                dev.set("index", device.index)?;
+                dev.set("vram_total", device.vram_total)?;
+                dev.set("vram_free", device.vram_free)?;
+                dev.set("torch_vram_total", device.torch_vram_total)?;
+                dev.set("torch_vram_free", device.torch_vram_free)?;
+                devices.set(i + 1, dev)?;
+            }
+            table.set("devices", devices)?;
+
+            Ok(table)
+        });
+
+        // Free memory and/or unload models.
+        methods.add_async_method(
+            "free",
+            |_lua, this, (unload_models, free_memory): (bool, bool)| async move {
+                to_lua_result(this.inner.free(unload_models, free_memory).await)?;
+                Ok(())
+            },
+        );
+
+        // ==================== Upload Operations ====================
+
+        // Upload an image to ComfyUI.
+        // Takes filename and bytes (as a Lua string).
+        methods.add_async_method(
+            "upload",
+            |lua, this, (filename, bytes): (String, LuaString)| async move {
+                let bytes_vec = bytes.as_bytes().to_vec();
+                let result = to_lua_result(this.inner.upload(&filename, bytes_vec).await)?;
+                lua.to_value(&result)
+            },
+        );
+    }
+}

--- a/crates/rucomfyui_mlua/src/config.rs
+++ b/crates/rucomfyui_mlua/src/config.rs
@@ -1,0 +1,136 @@
+//! Configuration types for rucomfyui_mlua.
+//!
+//! These types allow integrators to control which functionality is exposed to Lua.
+
+/// Configuration for which Client methods to expose to Lua.
+///
+/// Each field corresponds to a method on the Client type.
+/// If a field is `false`, the corresponding method will not be available in Lua.
+#[derive(Debug, Clone, Default)]
+pub struct ClientConfig {
+    // Object Info
+    /// Allow `get_object_info` - retrieves info about all available nodes.
+    pub get_object_info: bool,
+    /// Allow `get_object_for_name` - retrieves info about a specific node.
+    pub get_object_for_name: bool,
+
+    // Queue Operations
+    /// Allow `queue` - queues a workflow for execution.
+    pub queue: bool,
+    /// Allow `easy_queue` - queues a workflow and waits for results.
+    pub easy_queue: bool,
+    /// Allow `get_queue` - gets the current queue status.
+    pub get_queue: bool,
+    /// Allow `interrupt` - interrupts the current workflow.
+    pub interrupt: bool,
+    /// Allow `delete_from_queue` - deletes workflows from the queue.
+    pub delete_from_queue: bool,
+    /// Allow `clear_queue` - clears the entire queue.
+    pub clear_queue: bool,
+
+    // History Operations
+    /// Allow `get_history` - gets history with a maximum number of items.
+    pub get_history: bool,
+    /// Allow `get_history_for_prompt` - gets history for a specific prompt.
+    pub get_history_for_prompt: bool,
+    /// Allow `delete_from_history` - deletes entries from history.
+    pub delete_from_history: bool,
+    /// Allow `clear_history` - clears all history.
+    pub clear_history: bool,
+
+    // Model Operations
+    /// Allow `get_model_categories` - gets all model categories.
+    pub get_model_categories: bool,
+    /// Allow `get_models` - gets models in a category.
+    pub get_models: bool,
+
+    // System Operations
+    /// Allow `system_stats` - gets system statistics.
+    pub system_stats: bool,
+    /// Allow `free` - frees memory and/or unloads models.
+    pub free: bool,
+
+    // Upload Operations
+    /// Allow `upload` - uploads an image to ComfyUI.
+    pub upload: bool,
+}
+
+impl ClientConfig {
+    /// Create a config with all methods enabled.
+    pub fn all() -> Self {
+        Self {
+            get_object_info: true,
+            get_object_for_name: true,
+            queue: true,
+            easy_queue: true,
+            get_queue: true,
+            interrupt: true,
+            delete_from_queue: true,
+            clear_queue: true,
+            get_history: true,
+            get_history_for_prompt: true,
+            delete_from_history: true,
+            clear_history: true,
+            get_model_categories: true,
+            get_models: true,
+            system_stats: true,
+            free: true,
+            upload: true,
+        }
+    }
+
+    /// Create a config with no methods enabled.
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    /// Create a config with only read operations enabled.
+    ///
+    /// This includes: get_object_info, get_object_for_name, get_queue,
+    /// get_history, get_history_for_prompt, get_model_categories, get_models, system_stats
+    pub fn read_only() -> Self {
+        Self {
+            get_object_info: true,
+            get_object_for_name: true,
+            get_queue: true,
+            get_history: true,
+            get_history_for_prompt: true,
+            get_model_categories: true,
+            get_models: true,
+            system_stats: true,
+            ..Self::default()
+        }
+    }
+
+    /// Create a config suitable for executing workflows.
+    ///
+    /// This includes read operations plus: queue, easy_queue
+    pub fn execute() -> Self {
+        Self {
+            queue: true,
+            easy_queue: true,
+            ..Self::read_only()
+        }
+    }
+}
+
+/// Top-level configuration for the rucomfyui Lua module.
+#[derive(Debug, Clone, Default)]
+pub struct IntegrationConfig {
+    /// Configuration for Client methods.
+    pub client: ClientConfig,
+}
+
+impl IntegrationConfig {
+    /// Create a config with all functionality enabled.
+    pub fn all() -> Self {
+        Self {
+            client: ClientConfig::all(),
+        }
+    }
+
+    /// Create a config with no functionality enabled.
+    pub fn none() -> Self {
+        Self::default()
+    }
+}

--- a/crates/rucomfyui_mlua/src/conversion.rs
+++ b/crates/rucomfyui_mlua/src/conversion.rs
@@ -1,0 +1,82 @@
+//! Conversion utilities between Lua values and rucomfyui types.
+
+use crate::node_output::{NodeOutput, NodeOutputs};
+use mlua::prelude::*;
+use rucomfyui::workflow::WorkflowInput;
+
+/// Convert a Lua value to a WorkflowInput.
+///
+/// Handles:
+/// - Strings -> WorkflowInput::String
+/// - Integers -> WorkflowInput::I64
+/// - Numbers -> WorkflowInput::F64
+/// - Booleans -> WorkflowInput::Boolean
+/// - NodeOutput -> WorkflowInput::Slot
+/// - NodeOutputs -> WorkflowInput::Slot (uses first output, slot 0)
+pub fn lua_to_workflow_input(value: LuaValue) -> LuaResult<WorkflowInput> {
+    match value {
+        LuaValue::String(s) => Ok(WorkflowInput::String(s.to_str()?.to_string())),
+        LuaValue::Integer(i) => Ok(WorkflowInput::I64(i)),
+        LuaValue::Number(n) => {
+            // Check if it's actually an integer
+            if n.fract() == 0.0 && n >= i64::MIN as f64 && n <= i64::MAX as f64 {
+                Ok(WorkflowInput::I64(n as i64))
+            } else {
+                Ok(WorkflowInput::F64(n))
+            }
+        }
+        LuaValue::Boolean(b) => Ok(WorkflowInput::Boolean(b)),
+        LuaValue::UserData(ud) => {
+            // Try NodeOutput first
+            if let Ok(output) = ud.borrow::<NodeOutput>() {
+                return Ok(WorkflowInput::Slot(
+                    output.node_id.to_string(),
+                    output.slot,
+                ));
+            }
+            // Try NodeOutputs (use slot 0 by default)
+            if let Ok(outputs) = ud.borrow::<NodeOutputs>() {
+                return Ok(WorkflowInput::Slot(outputs.node_id.to_string(), 0));
+            }
+            Err(LuaError::external(
+                "Cannot convert userdata to workflow input",
+            ))
+        }
+        LuaValue::Nil => Err(LuaError::external("Cannot use nil as workflow input")),
+        LuaValue::Table(_) => Err(LuaError::external(
+            "Cannot use table directly as workflow input (did you mean to pass a node output?)",
+        )),
+        _ => Err(LuaError::external(format!(
+            "Cannot convert {:?} to workflow input",
+            value.type_name()
+        ))),
+    }
+}
+
+/// Check if a Lua value represents a node output.
+#[allow(dead_code)]
+pub fn is_node_output(value: &LuaValue) -> bool {
+    match value {
+        LuaValue::UserData(ud) => {
+            ud.borrow::<NodeOutput>().is_ok() || ud.borrow::<NodeOutputs>().is_ok()
+        }
+        _ => false,
+    }
+}
+
+/// Get the node ID from a Lua value if it's a node output.
+#[allow(dead_code)]
+pub fn get_node_id(value: &LuaValue) -> Option<u32> {
+    match value {
+        LuaValue::UserData(ud) => {
+            if let Ok(output) = ud.borrow::<NodeOutput>() {
+                return Some(output.node_id.0);
+            }
+            if let Ok(outputs) = ud.borrow::<NodeOutputs>() {
+                return Some(outputs.node_id.0);
+            }
+            None
+        }
+        _ => None,
+    }
+}

--- a/crates/rucomfyui_mlua/src/conversion.rs
+++ b/crates/rucomfyui_mlua/src/conversion.rs
@@ -53,30 +53,3 @@ pub fn lua_to_workflow_input(value: LuaValue) -> LuaResult<WorkflowInput> {
     }
 }
 
-/// Check if a Lua value represents a node output.
-#[allow(dead_code)]
-pub fn is_node_output(value: &LuaValue) -> bool {
-    match value {
-        LuaValue::UserData(ud) => {
-            ud.borrow::<NodeOutput>().is_ok() || ud.borrow::<NodeOutputs>().is_ok()
-        }
-        _ => false,
-    }
-}
-
-/// Get the node ID from a Lua value if it's a node output.
-#[allow(dead_code)]
-pub fn get_node_id(value: &LuaValue) -> Option<u32> {
-    match value {
-        LuaValue::UserData(ud) => {
-            if let Ok(output) = ud.borrow::<NodeOutput>() {
-                return Some(output.node_id.0);
-            }
-            if let Ok(outputs) = ud.borrow::<NodeOutputs>() {
-                return Some(outputs.node_id.0);
-            }
-            None
-        }
-        _ => None,
-    }
-}

--- a/crates/rucomfyui_mlua/src/error.rs
+++ b/crates/rucomfyui_mlua/src/error.rs
@@ -1,0 +1,47 @@
+//! Error types for rucomfyui_mlua.
+
+use mlua::prelude::*;
+
+/// Errors that can occur in rucomfyui_mlua.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A rucomfyui client error.
+    #[error("ComfyUI client error: {0}")]
+    Client(#[from] rucomfyui::ClientError),
+
+    /// An unknown node type was requested.
+    #[error("Unknown node type: {0}")]
+    UnknownNode(String),
+
+    /// A required input was missing.
+    #[error("Missing required input '{input}' for node '{node}'")]
+    MissingInput { node: String, input: String },
+
+    /// An input had an invalid type.
+    #[error("Invalid type for input '{input}' on node '{node}': expected {expected}, got {got}")]
+    InvalidInputType {
+        node: String,
+        input: String,
+        expected: String,
+        got: String,
+    },
+
+    /// An output field was not found.
+    #[error("Output '{output}' not found on node '{node}'")]
+    OutputNotFound { node: String, output: String },
+
+    /// A Lua error occurred.
+    #[error("Lua error: {0}")]
+    Lua(#[from] mlua::Error),
+}
+
+impl From<Error> for mlua::Error {
+    fn from(err: Error) -> Self {
+        mlua::Error::external(err)
+    }
+}
+
+/// Convert a rucomfyui Result to a Lua Result.
+pub fn to_lua_result<T>(result: rucomfyui::Result<T>) -> LuaResult<T> {
+    result.map_err(|e| mlua::Error::external(Error::Client(e)))
+}

--- a/crates/rucomfyui_mlua/src/graph.rs
+++ b/crates/rucomfyui_mlua/src/graph.rs
@@ -1,0 +1,541 @@
+//! Graph builder for ComfyUI workflows.
+
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, HashMap},
+};
+
+use mlua::prelude::*;
+use rucomfyui::{
+    object_info::{Object, ObjectInfo, ObjectType},
+    workflow::{Workflow, WorkflowInput, WorkflowMeta, WorkflowNode, WorkflowNodeId},
+};
+
+use crate::{
+    conversion::lua_to_workflow_input,
+    error::Error,
+    node_output::{NodeOutput, NodeOutputValue, NodeOutputs},
+};
+
+/// A workflow graph builder.
+///
+/// This is the main type for building ComfyUI workflows in Lua.
+/// Node types are exposed as methods via the `__index` metamethod.
+pub struct Graph {
+    /// The workflow being built.
+    workflow: RefCell<Workflow>,
+    /// The next node ID to assign.
+    next_id: RefCell<u32>,
+    /// Object info for node definitions.
+    object_info: ObjectInfo,
+}
+
+impl Graph {
+    /// Create a new graph from object info.
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(lua: &Lua, object_info_table: LuaTable) -> LuaResult<LuaAnyUserData> {
+        let object_info = parse_object_info(lua, object_info_table)?;
+
+        lua.create_userdata(Self {
+            workflow: RefCell::new(Workflow::default()),
+            next_id: RefCell::new(0),
+            object_info,
+        })
+    }
+
+    /// Add a node to the graph.
+    fn add_node(&self, node: WorkflowNode) -> WorkflowNodeId {
+        let mut next_id = self.next_id.borrow_mut();
+        *next_id += 1;
+        let id = WorkflowNodeId(*next_id);
+        self.workflow.borrow_mut().0.insert(id, node);
+        id
+    }
+
+    /// Get the object definition for a node type.
+    fn get_object(&self, name: &str) -> Option<&Object> {
+        self.object_info.get(name)
+    }
+
+    /// Convert the graph to a workflow.
+    pub fn to_workflow(&self) -> Workflow {
+        self.workflow.borrow().clone()
+    }
+}
+
+impl LuaUserData for Graph {
+    fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
+        // Get the underlying workflow as a Lua-compatible table
+        methods.add_method("_get_workflow", |lua, this, ()| {
+            let workflow = this.to_workflow();
+            lua.to_value(&workflow)
+        });
+
+        // The main magic: __index returns a node constructor for any node type
+        methods.add_meta_method(LuaMetaMethod::Index, |lua, this, key: String| {
+            // Check if it's a known node type
+            if let Some(object) = this.get_object(&key) {
+                // Return a constructor function for this node type
+                let object = object.clone();
+                let constructor = lua.create_function(move |lua, args: LuaMultiValue| {
+                    create_node(lua, &object, args)
+                })?;
+                Ok(LuaValue::Function(constructor))
+            } else {
+                // Unknown node type - return nil (let Lua handle the error)
+                Ok(LuaValue::Nil)
+            }
+        });
+    }
+}
+
+/// Create a node from Lua arguments.
+fn create_node(lua: &Lua, object: &Object, args: LuaMultiValue) -> LuaResult<LuaValue> {
+    // Get the graph from the first argument (self)
+    let mut args_iter = args.into_iter();
+    let graph_ud = args_iter
+        .next()
+        .ok_or_else(|| LuaError::external("Expected graph as first argument"))?;
+
+    let graph = match &graph_ud {
+        LuaValue::UserData(ud) => ud.borrow::<Graph>()?,
+        _ => return Err(LuaError::external("Expected graph as first argument")),
+    };
+
+    // Parse the remaining arguments into inputs
+    let inputs = parse_node_inputs(lua, object, args_iter.collect())?;
+
+    // Create the workflow node
+    let node = WorkflowNode {
+        inputs,
+        class_type: object.name.clone(),
+        meta: Some(WorkflowMeta::new(object.display_name())),
+    };
+
+    // Add to graph and create output
+    let node_id = graph.add_node(node);
+    let output = create_node_output(object, node_id);
+
+    output.into_lua(lua)
+}
+
+/// Parse Lua arguments into workflow inputs.
+fn parse_node_inputs(
+    _lua: &Lua,
+    object: &Object,
+    args: Vec<LuaValue>,
+) -> LuaResult<HashMap<String, WorkflowInput>> {
+    let mut inputs = HashMap::new();
+
+    // Collect input names in order
+    let input_names: Vec<&str> = object.all_inputs().map(|(name, _, _)| name).collect();
+
+    if args.is_empty() {
+        // No arguments - check if all inputs are optional
+        for (name, _input, required) in object.all_inputs() {
+            if required {
+                return Err(Error::MissingInput {
+                    node: object.name.clone(),
+                    input: name.to_string(),
+                }
+                .into());
+            }
+        }
+        return Ok(inputs);
+    }
+
+    // Check if first argument is a table (named arguments)
+    if let Some(LuaValue::Table(table)) = args.first() {
+        // Named arguments mode
+        for (name, _input, required) in object.all_inputs() {
+            let value: LuaValue = table.get(name)?;
+            if value.is_nil() {
+                if required {
+                    return Err(Error::MissingInput {
+                        node: object.name.clone(),
+                        input: name.to_string(),
+                    }
+                    .into());
+                }
+            } else {
+                inputs.insert(name.to_string(), lua_to_workflow_input(value)?);
+            }
+        }
+    } else {
+        // Positional arguments mode
+        for (i, value) in args.into_iter().enumerate() {
+            if i >= input_names.len() {
+                break; // Extra arguments ignored
+            }
+            let name = input_names[i];
+            inputs.insert(name.to_string(), lua_to_workflow_input(value)?);
+        }
+
+        // Check for missing required inputs
+        for (name, _input, required) in object.all_inputs() {
+            if required && !inputs.contains_key(name) {
+                return Err(Error::MissingInput {
+                    node: object.name.clone(),
+                    input: name.to_string(),
+                }
+                .into());
+            }
+        }
+    }
+
+    Ok(inputs)
+}
+
+/// Create the appropriate output type for a node.
+fn create_node_output(object: &Object, node_id: WorkflowNodeId) -> NodeOutputValue {
+    if object.output.len() <= 1 {
+        // Single output or output node
+        NodeOutputValue::Single(NodeOutput::new(node_id, 0))
+    } else {
+        // Multiple outputs - create named outputs
+        let mut outputs = HashMap::new();
+        for (i, name) in object.output_name.iter().enumerate() {
+            // Convert output name to snake_case for Lua field access
+            let lua_name = to_snake_case(name);
+            outputs.insert(lua_name, i as u32);
+        }
+        NodeOutputValue::Multiple(NodeOutputs::new(node_id, outputs))
+    }
+}
+
+/// Convert a string to snake_case.
+fn to_snake_case(s: &str) -> String {
+    let mut result = String::new();
+    for (i, c) in s.chars().enumerate() {
+        if c.is_uppercase() {
+            if i > 0 {
+                result.push('_');
+            }
+            result.push(c.to_lowercase().next().unwrap());
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+/// Parse a Lua table into ObjectInfo.
+fn parse_object_info(_lua: &Lua, table: LuaTable) -> LuaResult<ObjectInfo> {
+    // The table should be the result of client:get_object_info()
+    // which is already a properly structured ObjectInfo
+    let mut object_info = BTreeMap::new();
+
+    for pair in table.pairs::<String, LuaTable>() {
+        let (name, obj_table) = pair?;
+        let object = parse_object(&name, obj_table)?;
+        object_info.insert(name, object);
+    }
+
+    Ok(object_info)
+}
+
+/// Parse a single object definition from Lua.
+fn parse_object(name: &str, table: LuaTable) -> LuaResult<Object> {
+    use rucomfyui::object_info::*;
+
+    let display_name: Option<String> = table.get("display_name")?;
+    let description: String = table.get::<String>("description").unwrap_or_default();
+    let python_module: String = table.get::<String>("python_module").unwrap_or_default();
+    let category: String = table.get::<String>("category").unwrap_or_default();
+    let output_node: bool = table.get("output_node").unwrap_or(false);
+
+    // Parse outputs
+    let output = parse_output_types(table.get::<LuaTable>("output")?)?;
+    let output_is_list = parse_bool_array(table.get::<LuaTable>("output_is_list")?)?;
+    let output_name = parse_string_array(table.get::<LuaTable>("output_name")?)?;
+    let output_tooltips = table
+        .get::<LuaTable>("output_tooltips")
+        .ok()
+        .map(|t| parse_optional_string_array(t).unwrap_or_default())
+        .unwrap_or_default();
+
+    // Parse inputs
+    let input_table: LuaTable = table.get("input")?;
+    let input_order_table: LuaTable = table.get("input_order")?;
+
+    let required_inputs = parse_inputs(input_table.get::<LuaTable>("required")?)?;
+    let optional_inputs = input_table
+        .get::<LuaTable>("optional")
+        .ok()
+        .map(parse_inputs)
+        .transpose()?;
+
+    let required_order = parse_string_array(input_order_table.get::<LuaTable>("required")?)?;
+    let optional_order = input_order_table
+        .get::<LuaTable>("optional")
+        .ok()
+        .map(parse_string_array)
+        .transpose()?;
+
+    Ok(Object {
+        name: name.to_string(),
+        display_name,
+        description,
+        python_module,
+        category,
+        input: ObjectInputBundle {
+            required: required_inputs,
+            optional: optional_inputs,
+        },
+        input_order: ObjectInputBundle {
+            required: required_order,
+            optional: optional_order,
+        },
+        output,
+        output_is_list,
+        output_name,
+        output_node,
+        output_tooltips,
+    })
+}
+
+fn parse_output_types(table: LuaTable) -> LuaResult<Vec<ObjectType>> {
+    let mut result = Vec::new();
+    for value in table.sequence_values::<String>() {
+        let type_str = value?;
+        let object_type = parse_object_type(&type_str);
+        result.push(object_type);
+    }
+    Ok(result)
+}
+
+fn parse_object_type(s: &str) -> ObjectType {
+    // Try to match known types
+    match s {
+        "ACCESSORIES_OPTIONS" => ObjectType::AccessoriesOptions,
+        "AUDIO" => ObjectType::Audio,
+        "AUDIO_ENCODER" => ObjectType::AudioEncoder,
+        "AUDIO_ENCODER_OUTPUT" => ObjectType::AudioEncoderOutput,
+        "BOOLEAN" => ObjectType::Boolean,
+        "CAMERA_CONTROL" => ObjectType::CameraControl,
+        "CLIP" => ObjectType::Clip,
+        "CLIP_VISION" => ObjectType::ClipVision,
+        "CLIP_VISION_OUTPUT" => ObjectType::ClipVisionOutput,
+        "CONDITIONING" => ObjectType::Conditioning,
+        "CONTROL_NET" => ObjectType::ControlNet,
+        "FLOAT" => ObjectType::Float,
+        "GEMINI_INPUT_FILES" => ObjectType::GeminiInputFiles,
+        "GLIGEN" => ObjectType::Gligen,
+        "GUIDER" => ObjectType::Guider,
+        "HOOK_KEYFRAMES" => ObjectType::HookKeyframes,
+        "HOOKS" => ObjectType::Hooks,
+        "IMAGE" => ObjectType::Image,
+        "INPAINT_MODEL" => ObjectType::InpaintModel,
+        "INPAINT_PATCH" => ObjectType::InpaintPatch,
+        "INT" => ObjectType::Int,
+        "LATENT" => ObjectType::Latent,
+        "LATENT_OPERATION" => ObjectType::LatentOperation,
+        "LOAD3D_CAMERA" => ObjectType::Load3DCamera,
+        "LORA_MODEL" => ObjectType::LoraModel,
+        "LOSS_MAP" => ObjectType::LossMap,
+        "LUMA_CONCEPTS" => ObjectType::LumaConcepts,
+        "LUMA_REF" => ObjectType::LumaRef,
+        "MASK" => ObjectType::Mask,
+        "MESH" => ObjectType::Mesh,
+        "MODEL" => ObjectType::Model,
+        "MODEL_PATCH" => ObjectType::ModelPatch,
+        "NOISE" => ObjectType::Noise,
+        "OPENAI_CHAT_CONFIG" => ObjectType::OpenAiChatConfig,
+        "OPENAI_INPUT_FILES" => ObjectType::OpenAiInputFiles,
+        "PHOTOMAKER" => ObjectType::Photomaker,
+        "PIXVERSE_TEMPLATE" => ObjectType::PixverseTemplate,
+        "RECRAFT_COLOR" => ObjectType::RecraftColor,
+        "RECRAFT_CONTROLS" => ObjectType::RecraftControls,
+        "RECRAFT_V3_STYLE" => ObjectType::RecraftV3Style,
+        "SAMPLER" => ObjectType::Sampler,
+        "SIGMAS" => ObjectType::Sigmas,
+        "STRING" => ObjectType::String,
+        "STYLE_MODEL" => ObjectType::StyleModel,
+        "SVG" => ObjectType::Svg,
+        "TIMESTEPS_RANGE" => ObjectType::TimestepsRange,
+        "UPSCALE_MODEL" => ObjectType::UpscaleModel,
+        "VAE" => ObjectType::Vae,
+        "VIDEO" => ObjectType::Video,
+        "VOXEL" => ObjectType::Voxel,
+        "WAN_CAMERA_EMBEDDING" => ObjectType::WanCameraEmbedding,
+        "WEBCAM" => ObjectType::Webcam,
+        "*" => ObjectType::Wildcard,
+        other => ObjectType::Other(other.to_string()),
+    }
+}
+
+fn parse_bool_array(table: LuaTable) -> LuaResult<Vec<bool>> {
+    table.sequence_values::<bool>().collect()
+}
+
+fn parse_string_array(table: LuaTable) -> LuaResult<Vec<String>> {
+    table.sequence_values::<String>().collect()
+}
+
+fn parse_optional_string_array(table: LuaTable) -> LuaResult<Vec<Option<String>>> {
+    let mut result = Vec::new();
+    for value in table.sequence_values::<LuaValue>() {
+        let v = value?;
+        match v {
+            LuaValue::Nil => result.push(None),
+            LuaValue::String(s) => result.push(Some(s.to_str()?.to_string())),
+            _ => result.push(None),
+        }
+    }
+    Ok(result)
+}
+
+fn parse_inputs(table: LuaTable) -> LuaResult<BTreeMap<String, rucomfyui::object_info::ObjectInput>>
+{
+    use rucomfyui::object_info::*;
+
+    let mut result = BTreeMap::new();
+
+    for pair in table.pairs::<String, LuaValue>() {
+        let (name, value) = pair?;
+
+        // Each input is an array: [type, meta?]
+        let input = match value {
+            LuaValue::Table(arr) => {
+                let type_value: LuaValue = arr.get(1)?;
+                let meta_value: Option<LuaTable> = arr.get(2).ok();
+
+                let input_type = parse_input_type(type_value)?;
+                let input_meta = meta_value
+                    .map(parse_input_meta)
+                    .transpose()?
+                    .unwrap_or(ObjectInputMeta {
+                        tooltip: None,
+                        typed: None,
+                    });
+
+                ObjectInput::InputWithMeta(input_type, input_meta)
+            }
+            _ => continue, // Skip malformed inputs
+        };
+
+        result.insert(name, input);
+    }
+
+    Ok(result)
+}
+
+fn parse_input_type(value: LuaValue) -> LuaResult<rucomfyui::object_info::ObjectInputType> {
+    use rucomfyui::object_info::*;
+
+    match value {
+        LuaValue::String(s) => {
+            let type_str = s.to_str()?;
+            Ok(ObjectInputType::Typed(parse_object_type(&type_str)))
+        }
+        LuaValue::Table(arr) => {
+            // Array of string options
+            let mut options = Vec::new();
+            for v in arr.sequence_values::<LuaValue>() {
+                match v? {
+                    LuaValue::String(s) => {
+                        options.push(ObjectInputTypeArrayValue::String(s.to_str()?.to_string()));
+                    }
+                    LuaValue::Table(t) => {
+                        // ContentImage format
+                        let content: String = t.get("content").unwrap_or_default();
+                        let image: Option<String> = t.get("image").ok();
+                        options.push(ObjectInputTypeArrayValue::ContentImage { content, image });
+                    }
+                    _ => {}
+                }
+            }
+            Ok(ObjectInputType::Array(options))
+        }
+        _ => Err(LuaError::external("Invalid input type")),
+    }
+}
+
+fn parse_input_meta(table: LuaTable) -> LuaResult<rucomfyui::object_info::ObjectInputMeta> {
+    use rucomfyui::object_info::*;
+
+    let tooltip: Option<String> = table.get("tooltip").ok();
+
+    // Try to determine typed metadata
+    let typed = if let Ok(default) = table.get::<bool>("default") {
+        Some(ObjectInputMetaTyped::Boolean(ObjectInputMetaTypedBoolean {
+            default,
+        }))
+    } else if table.contains_key("image_upload")? {
+        Some(ObjectInputMetaTyped::Image(ObjectInputMetaTypedImage {
+            image_upload: table.get("image_upload").unwrap_or(false),
+        }))
+    } else if table.contains_key("audio_upload")? {
+        Some(ObjectInputMetaTyped::Audio(ObjectInputMetaTypedAudio {
+            audio_upload: table.get("audio_upload").unwrap_or(false),
+        }))
+    } else if table.contains_key("multiline")? || table.contains_key("dynamicPrompts")? {
+        Some(ObjectInputMetaTyped::String(ObjectInputMetaTypedString {
+            dynamic_prompts: table.get("dynamicPrompts").ok(),
+            multiline: table.get("multiline").ok(),
+            default: table.get("default").ok(),
+        }))
+    } else if table.contains_key("min")? || table.contains_key("max")? {
+        Some(ObjectInputMetaTyped::Number(ObjectInputMetaTypedNumber {
+            default: parse_number_value(table.get::<LuaValue>("default")?)?,
+            display: table.get("display").ok(),
+            max: parse_number_value(table.get::<LuaValue>("max")?)?,
+            min: parse_number_value(table.get::<LuaValue>("min")?)?,
+            round: table
+                .get::<LuaValue>("round")
+                .ok()
+                .map(parse_round_value)
+                .transpose()?,
+            step: table
+                .get::<LuaValue>("step")
+                .ok()
+                .map(parse_number_value)
+                .transpose()?,
+        }))
+    } else {
+        None
+    };
+
+    Ok(ObjectInputMeta { tooltip, typed })
+}
+
+fn parse_number_value(
+    value: LuaValue,
+) -> LuaResult<rucomfyui::object_info::ObjectInputMetaTypedNumberValue> {
+    use rucomfyui::object_info::ObjectInputMetaTypedNumberValue;
+
+    match value {
+        LuaValue::Integer(i) => {
+            if i >= 0 {
+                Ok(ObjectInputMetaTypedNumberValue::U64(i as u64))
+            } else {
+                Ok(ObjectInputMetaTypedNumberValue::I64(i))
+            }
+        }
+        LuaValue::Number(n) => {
+            if n.fract() == 0.0 {
+                if n >= 0.0 {
+                    Ok(ObjectInputMetaTypedNumberValue::U64(n as u64))
+                } else {
+                    Ok(ObjectInputMetaTypedNumberValue::I64(n as i64))
+                }
+            } else {
+                Ok(ObjectInputMetaTypedNumberValue::F64(n))
+            }
+        }
+        _ => Ok(ObjectInputMetaTypedNumberValue::I64(0)),
+    }
+}
+
+fn parse_round_value(
+    value: LuaValue,
+) -> LuaResult<rucomfyui::object_info::ObjectInputMetaTypedRoundValue> {
+    use rucomfyui::object_info::ObjectInputMetaTypedRoundValue;
+
+    match value {
+        LuaValue::Boolean(b) => Ok(ObjectInputMetaTypedRoundValue::Bool(b)),
+        LuaValue::Integer(i) => Ok(ObjectInputMetaTypedRoundValue::Number(i as f64)),
+        LuaValue::Number(n) => Ok(ObjectInputMetaTypedRoundValue::Number(n)),
+        _ => Ok(ObjectInputMetaTypedRoundValue::Bool(false)),
+    }
+}

--- a/crates/rucomfyui_mlua/src/graph.rs
+++ b/crates/rucomfyui_mlua/src/graph.rs
@@ -1,13 +1,10 @@
 //! Graph builder for ComfyUI workflows.
 
-use std::{
-    cell::RefCell,
-    collections::{BTreeMap, HashMap},
-};
+use std::{cell::RefCell, collections::HashMap};
 
 use mlua::prelude::*;
 use rucomfyui::{
-    object_info::{Object, ObjectInfo, ObjectType},
+    object_info::{Object, ObjectInfo},
     workflow::{Workflow, WorkflowInput, WorkflowMeta, WorkflowNode, WorkflowNodeId},
 };
 
@@ -34,7 +31,8 @@ impl Graph {
     /// Create a new graph from object info.
     #[allow(clippy::new_ret_no_self)]
     pub fn new(lua: &Lua, object_info_table: LuaTable) -> LuaResult<LuaAnyUserData> {
-        let object_info = parse_object_info(lua, object_info_table)?;
+        // Use mlua's serde feature to deserialize the Lua table directly
+        let object_info: ObjectInfo = lua.from_value(LuaValue::Table(object_info_table))?;
 
         lua.create_userdata(Self {
             workflow: RefCell::new(Workflow::default()),
@@ -103,7 +101,7 @@ fn create_node(lua: &Lua, object: &Object, args: LuaMultiValue) -> LuaResult<Lua
     };
 
     // Parse the remaining arguments into inputs
-    let inputs = parse_node_inputs(lua, object, args_iter.collect())?;
+    let inputs = parse_node_inputs(object, args_iter.collect())?;
 
     // Create the workflow node
     let node = WorkflowNode {
@@ -121,7 +119,6 @@ fn create_node(lua: &Lua, object: &Object, args: LuaMultiValue) -> LuaResult<Lua
 
 /// Parse Lua arguments into workflow inputs.
 fn parse_node_inputs(
-    _lua: &Lua,
     object: &Object,
     args: Vec<LuaValue>,
 ) -> LuaResult<HashMap<String, WorkflowInput>> {
@@ -217,325 +214,4 @@ fn to_snake_case(s: &str) -> String {
         }
     }
     result
-}
-
-/// Parse a Lua table into ObjectInfo.
-fn parse_object_info(_lua: &Lua, table: LuaTable) -> LuaResult<ObjectInfo> {
-    // The table should be the result of client:get_object_info()
-    // which is already a properly structured ObjectInfo
-    let mut object_info = BTreeMap::new();
-
-    for pair in table.pairs::<String, LuaTable>() {
-        let (name, obj_table) = pair?;
-        let object = parse_object(&name, obj_table)?;
-        object_info.insert(name, object);
-    }
-
-    Ok(object_info)
-}
-
-/// Parse a single object definition from Lua.
-fn parse_object(name: &str, table: LuaTable) -> LuaResult<Object> {
-    use rucomfyui::object_info::*;
-
-    let display_name: Option<String> = table.get("display_name")?;
-    let description: String = table.get::<String>("description").unwrap_or_default();
-    let python_module: String = table.get::<String>("python_module").unwrap_or_default();
-    let category: String = table.get::<String>("category").unwrap_or_default();
-    let output_node: bool = table.get("output_node").unwrap_or(false);
-
-    // Parse outputs
-    let output = parse_output_types(table.get::<LuaTable>("output")?)?;
-    let output_is_list = parse_bool_array(table.get::<LuaTable>("output_is_list")?)?;
-    let output_name = parse_string_array(table.get::<LuaTable>("output_name")?)?;
-    let output_tooltips = table
-        .get::<LuaTable>("output_tooltips")
-        .ok()
-        .map(|t| parse_optional_string_array(t).unwrap_or_default())
-        .unwrap_or_default();
-
-    // Parse inputs
-    let input_table: LuaTable = table.get("input")?;
-    let input_order_table: LuaTable = table.get("input_order")?;
-
-    let required_inputs = parse_inputs(input_table.get::<LuaTable>("required")?)?;
-    let optional_inputs = input_table
-        .get::<LuaTable>("optional")
-        .ok()
-        .map(parse_inputs)
-        .transpose()?;
-
-    let required_order = parse_string_array(input_order_table.get::<LuaTable>("required")?)?;
-    let optional_order = input_order_table
-        .get::<LuaTable>("optional")
-        .ok()
-        .map(parse_string_array)
-        .transpose()?;
-
-    Ok(Object {
-        name: name.to_string(),
-        display_name,
-        description,
-        python_module,
-        category,
-        input: ObjectInputBundle {
-            required: required_inputs,
-            optional: optional_inputs,
-        },
-        input_order: ObjectInputBundle {
-            required: required_order,
-            optional: optional_order,
-        },
-        output,
-        output_is_list,
-        output_name,
-        output_node,
-        output_tooltips,
-    })
-}
-
-fn parse_output_types(table: LuaTable) -> LuaResult<Vec<ObjectType>> {
-    let mut result = Vec::new();
-    for value in table.sequence_values::<String>() {
-        let type_str = value?;
-        let object_type = parse_object_type(&type_str);
-        result.push(object_type);
-    }
-    Ok(result)
-}
-
-fn parse_object_type(s: &str) -> ObjectType {
-    // Try to match known types
-    match s {
-        "ACCESSORIES_OPTIONS" => ObjectType::AccessoriesOptions,
-        "AUDIO" => ObjectType::Audio,
-        "AUDIO_ENCODER" => ObjectType::AudioEncoder,
-        "AUDIO_ENCODER_OUTPUT" => ObjectType::AudioEncoderOutput,
-        "BOOLEAN" => ObjectType::Boolean,
-        "CAMERA_CONTROL" => ObjectType::CameraControl,
-        "CLIP" => ObjectType::Clip,
-        "CLIP_VISION" => ObjectType::ClipVision,
-        "CLIP_VISION_OUTPUT" => ObjectType::ClipVisionOutput,
-        "CONDITIONING" => ObjectType::Conditioning,
-        "CONTROL_NET" => ObjectType::ControlNet,
-        "FLOAT" => ObjectType::Float,
-        "GEMINI_INPUT_FILES" => ObjectType::GeminiInputFiles,
-        "GLIGEN" => ObjectType::Gligen,
-        "GUIDER" => ObjectType::Guider,
-        "HOOK_KEYFRAMES" => ObjectType::HookKeyframes,
-        "HOOKS" => ObjectType::Hooks,
-        "IMAGE" => ObjectType::Image,
-        "INPAINT_MODEL" => ObjectType::InpaintModel,
-        "INPAINT_PATCH" => ObjectType::InpaintPatch,
-        "INT" => ObjectType::Int,
-        "LATENT" => ObjectType::Latent,
-        "LATENT_OPERATION" => ObjectType::LatentOperation,
-        "LOAD3D_CAMERA" => ObjectType::Load3DCamera,
-        "LORA_MODEL" => ObjectType::LoraModel,
-        "LOSS_MAP" => ObjectType::LossMap,
-        "LUMA_CONCEPTS" => ObjectType::LumaConcepts,
-        "LUMA_REF" => ObjectType::LumaRef,
-        "MASK" => ObjectType::Mask,
-        "MESH" => ObjectType::Mesh,
-        "MODEL" => ObjectType::Model,
-        "MODEL_PATCH" => ObjectType::ModelPatch,
-        "NOISE" => ObjectType::Noise,
-        "OPENAI_CHAT_CONFIG" => ObjectType::OpenAiChatConfig,
-        "OPENAI_INPUT_FILES" => ObjectType::OpenAiInputFiles,
-        "PHOTOMAKER" => ObjectType::Photomaker,
-        "PIXVERSE_TEMPLATE" => ObjectType::PixverseTemplate,
-        "RECRAFT_COLOR" => ObjectType::RecraftColor,
-        "RECRAFT_CONTROLS" => ObjectType::RecraftControls,
-        "RECRAFT_V3_STYLE" => ObjectType::RecraftV3Style,
-        "SAMPLER" => ObjectType::Sampler,
-        "SIGMAS" => ObjectType::Sigmas,
-        "STRING" => ObjectType::String,
-        "STYLE_MODEL" => ObjectType::StyleModel,
-        "SVG" => ObjectType::Svg,
-        "TIMESTEPS_RANGE" => ObjectType::TimestepsRange,
-        "UPSCALE_MODEL" => ObjectType::UpscaleModel,
-        "VAE" => ObjectType::Vae,
-        "VIDEO" => ObjectType::Video,
-        "VOXEL" => ObjectType::Voxel,
-        "WAN_CAMERA_EMBEDDING" => ObjectType::WanCameraEmbedding,
-        "WEBCAM" => ObjectType::Webcam,
-        "*" => ObjectType::Wildcard,
-        other => ObjectType::Other(other.to_string()),
-    }
-}
-
-fn parse_bool_array(table: LuaTable) -> LuaResult<Vec<bool>> {
-    table.sequence_values::<bool>().collect()
-}
-
-fn parse_string_array(table: LuaTable) -> LuaResult<Vec<String>> {
-    table.sequence_values::<String>().collect()
-}
-
-fn parse_optional_string_array(table: LuaTable) -> LuaResult<Vec<Option<String>>> {
-    let mut result = Vec::new();
-    for value in table.sequence_values::<LuaValue>() {
-        let v = value?;
-        match v {
-            LuaValue::Nil => result.push(None),
-            LuaValue::String(s) => result.push(Some(s.to_str()?.to_string())),
-            _ => result.push(None),
-        }
-    }
-    Ok(result)
-}
-
-fn parse_inputs(table: LuaTable) -> LuaResult<BTreeMap<String, rucomfyui::object_info::ObjectInput>>
-{
-    use rucomfyui::object_info::*;
-
-    let mut result = BTreeMap::new();
-
-    for pair in table.pairs::<String, LuaValue>() {
-        let (name, value) = pair?;
-
-        // Each input is an array: [type, meta?]
-        let input = match value {
-            LuaValue::Table(arr) => {
-                let type_value: LuaValue = arr.get(1)?;
-                let meta_value: Option<LuaTable> = arr.get(2).ok();
-
-                let input_type = parse_input_type(type_value)?;
-                let input_meta = meta_value
-                    .map(parse_input_meta)
-                    .transpose()?
-                    .unwrap_or(ObjectInputMeta {
-                        tooltip: None,
-                        typed: None,
-                    });
-
-                ObjectInput::InputWithMeta(input_type, input_meta)
-            }
-            _ => continue, // Skip malformed inputs
-        };
-
-        result.insert(name, input);
-    }
-
-    Ok(result)
-}
-
-fn parse_input_type(value: LuaValue) -> LuaResult<rucomfyui::object_info::ObjectInputType> {
-    use rucomfyui::object_info::*;
-
-    match value {
-        LuaValue::String(s) => {
-            let type_str = s.to_str()?;
-            Ok(ObjectInputType::Typed(parse_object_type(&type_str)))
-        }
-        LuaValue::Table(arr) => {
-            // Array of string options
-            let mut options = Vec::new();
-            for v in arr.sequence_values::<LuaValue>() {
-                match v? {
-                    LuaValue::String(s) => {
-                        options.push(ObjectInputTypeArrayValue::String(s.to_str()?.to_string()));
-                    }
-                    LuaValue::Table(t) => {
-                        // ContentImage format
-                        let content: String = t.get("content").unwrap_or_default();
-                        let image: Option<String> = t.get("image").ok();
-                        options.push(ObjectInputTypeArrayValue::ContentImage { content, image });
-                    }
-                    _ => {}
-                }
-            }
-            Ok(ObjectInputType::Array(options))
-        }
-        _ => Err(LuaError::external("Invalid input type")),
-    }
-}
-
-fn parse_input_meta(table: LuaTable) -> LuaResult<rucomfyui::object_info::ObjectInputMeta> {
-    use rucomfyui::object_info::*;
-
-    let tooltip: Option<String> = table.get("tooltip").ok();
-
-    // Try to determine typed metadata
-    let typed = if let Ok(default) = table.get::<bool>("default") {
-        Some(ObjectInputMetaTyped::Boolean(ObjectInputMetaTypedBoolean {
-            default,
-        }))
-    } else if table.contains_key("image_upload")? {
-        Some(ObjectInputMetaTyped::Image(ObjectInputMetaTypedImage {
-            image_upload: table.get("image_upload").unwrap_or(false),
-        }))
-    } else if table.contains_key("audio_upload")? {
-        Some(ObjectInputMetaTyped::Audio(ObjectInputMetaTypedAudio {
-            audio_upload: table.get("audio_upload").unwrap_or(false),
-        }))
-    } else if table.contains_key("multiline")? || table.contains_key("dynamicPrompts")? {
-        Some(ObjectInputMetaTyped::String(ObjectInputMetaTypedString {
-            dynamic_prompts: table.get("dynamicPrompts").ok(),
-            multiline: table.get("multiline").ok(),
-            default: table.get("default").ok(),
-        }))
-    } else if table.contains_key("min")? || table.contains_key("max")? {
-        Some(ObjectInputMetaTyped::Number(ObjectInputMetaTypedNumber {
-            default: parse_number_value(table.get::<LuaValue>("default")?)?,
-            display: table.get("display").ok(),
-            max: parse_number_value(table.get::<LuaValue>("max")?)?,
-            min: parse_number_value(table.get::<LuaValue>("min")?)?,
-            round: table
-                .get::<LuaValue>("round")
-                .ok()
-                .map(parse_round_value)
-                .transpose()?,
-            step: table
-                .get::<LuaValue>("step")
-                .ok()
-                .map(parse_number_value)
-                .transpose()?,
-        }))
-    } else {
-        None
-    };
-
-    Ok(ObjectInputMeta { tooltip, typed })
-}
-
-fn parse_number_value(
-    value: LuaValue,
-) -> LuaResult<rucomfyui::object_info::ObjectInputMetaTypedNumberValue> {
-    use rucomfyui::object_info::ObjectInputMetaTypedNumberValue;
-
-    match value {
-        LuaValue::Integer(i) => {
-            if i >= 0 {
-                Ok(ObjectInputMetaTypedNumberValue::U64(i as u64))
-            } else {
-                Ok(ObjectInputMetaTypedNumberValue::I64(i))
-            }
-        }
-        LuaValue::Number(n) => {
-            if n.fract() == 0.0 {
-                if n >= 0.0 {
-                    Ok(ObjectInputMetaTypedNumberValue::U64(n as u64))
-                } else {
-                    Ok(ObjectInputMetaTypedNumberValue::I64(n as i64))
-                }
-            } else {
-                Ok(ObjectInputMetaTypedNumberValue::F64(n))
-            }
-        }
-        _ => Ok(ObjectInputMetaTypedNumberValue::I64(0)),
-    }
-}
-
-fn parse_round_value(
-    value: LuaValue,
-) -> LuaResult<rucomfyui::object_info::ObjectInputMetaTypedRoundValue> {
-    use rucomfyui::object_info::ObjectInputMetaTypedRoundValue;
-
-    match value {
-        LuaValue::Boolean(b) => Ok(ObjectInputMetaTypedRoundValue::Bool(b)),
-        LuaValue::Integer(i) => Ok(ObjectInputMetaTypedRoundValue::Number(i as f64)),
-        LuaValue::Number(n) => Ok(ObjectInputMetaTypedRoundValue::Number(n)),
-        _ => Ok(ObjectInputMetaTypedRoundValue::Bool(false)),
-    }
 }

--- a/crates/rucomfyui_mlua/src/graph.rs
+++ b/crates/rucomfyui_mlua/src/graph.rs
@@ -2,6 +2,7 @@
 
 use std::{cell::RefCell, collections::HashMap};
 
+use convert_case::{Case, Casing};
 use mlua::prelude::*;
 use rucomfyui::{
     object_info::{Object, ObjectInfo},
@@ -193,41 +194,9 @@ fn create_node_output(object: &Object, node_id: WorkflowNodeId) -> NodeOutputVal
         let mut outputs = HashMap::new();
         for (i, name) in object.output_name.iter().enumerate() {
             // Convert output name to snake_case for Lua field access
-            let lua_name = to_snake_case(name);
+            let lua_name = name.to_case(Case::Snake);
             outputs.insert(lua_name, i as u32);
         }
         NodeOutputValue::Multiple(NodeOutputs::new(node_id, outputs))
     }
-}
-
-/// Convert a string to snake_case.
-/// Handles ALL_CAPS words correctly (e.g., "CLIP" -> "clip", "VAE" -> "vae").
-fn to_snake_case(s: &str) -> String {
-    // If the string is all uppercase, just lowercase it
-    if s.chars().all(|c| c.is_uppercase() || !c.is_alphabetic()) {
-        return s.to_lowercase();
-    }
-
-    let mut result = String::new();
-    let chars: Vec<char> = s.chars().collect();
-
-    for (i, &c) in chars.iter().enumerate() {
-        if c.is_uppercase() {
-            // Check if we're in the middle of an acronym (current and next are uppercase)
-            let next_is_upper = chars.get(i + 1).is_some_and(|&n| n.is_uppercase());
-            let prev_is_upper = i > 0 && chars.get(i - 1).is_some_and(|&p| p.is_uppercase());
-
-            // Add underscore before this char if:
-            // - We're not at the start
-            // - Previous char was lowercase, OR
-            // - We're at the end of an acronym (prev is upper, next is lower or end)
-            if i > 0 && (!prev_is_upper || (!next_is_upper && i + 1 < chars.len())) {
-                result.push('_');
-            }
-            result.push(c.to_lowercase().next().unwrap());
-        } else {
-            result.push(c);
-        }
-    }
-    result
 }

--- a/crates/rucomfyui_mlua/src/lib.rs
+++ b/crates/rucomfyui_mlua/src/lib.rs
@@ -1,0 +1,93 @@
+//! Lua bindings for rucomfyui - a fluent ComfyUI workflow builder.
+//!
+//! This crate provides a high-level Lua API for building and executing ComfyUI workflows.
+//! It's designed to be embedded in Rust applications using mlua.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use mlua::Lua;
+//!
+//! # fn main() -> mlua::Result<()> {
+//! let lua = Lua::new();
+//!
+//! // Install the module
+//! let comfy = rucomfyui_mlua::module(&lua)?;
+//! lua.globals().set("comfy", comfy)?;
+//!
+//! // Use from Lua
+//! lua.load(r#"
+//!     local client = comfy.client("http://127.0.0.1:8188")
+//!     local object_info = client:get_object_info()
+//!     local g = comfy.graph(object_info)
+//!
+//!     local c = g:CheckpointLoaderSimple("sd_xl_base_1.0.safetensors")
+//!     local preview = g:PreviewImage(
+//!         g:VAEDecode {
+//!             vae = c.vae,
+//!             samples = g:KSampler {
+//!                 model = c.model,
+//!                 seed = 0,
+//!                 steps = 20,
+//!                 cfg = 8.0,
+//!                 sampler_name = "euler",
+//!                 scheduler = "normal",
+//!                 positive = g:CLIPTextEncode { text = "a cat", clip = c.clip },
+//!                 negative = g:CLIPTextEncode { text = "text", clip = c.clip },
+//!                 latent_image = g:EmptyLatentImage { width = 1024, height = 1024, batch_size = 1 },
+//!                 denoise = 1.0
+//!             }
+//!         }
+//!     )
+//!
+//!     local result = client:queue(g)
+//!     for i, image in ipairs(result[preview].images) do
+//!         -- image is raw bytes
+//!     end
+//! "#).exec()?;
+//! # Ok(())
+//! # }
+//! ```
+
+mod client;
+mod conversion;
+mod error;
+mod graph;
+mod node_output;
+
+pub use error::Error;
+
+use mlua::{Lua, Result, Table};
+
+/// Create the rucomfyui Lua module.
+///
+/// This returns a table containing the module's functions and types.
+/// The integrator can place this table wherever they like in the Lua environment.
+///
+/// # Example
+///
+/// ```no_run
+/// use mlua::Lua;
+///
+/// let lua = Lua::new();
+/// let comfy = rucomfyui_mlua::module(&lua)?;
+/// lua.globals().set("comfy", comfy)?;
+/// # Ok::<(), mlua::Error>(())
+/// ```
+pub fn module(lua: &Lua) -> Result<Table> {
+    let exports = lua.create_table()?;
+
+    // comfy.client(url) -> Client
+    exports.set(
+        "client",
+        lua.create_function(|lua, url: String| client::Client::new(lua, url))?,
+    )?;
+
+    // comfy.graph(object_info) -> Graph
+    exports.set(
+        "graph",
+        lua.create_function(|lua, object_info: Table| graph::Graph::new(lua, object_info))?,
+    )?;
+
+    Ok(exports)
+}

--- a/crates/rucomfyui_mlua/src/lib.rs
+++ b/crates/rucomfyui_mlua/src/lib.rs
@@ -7,12 +7,14 @@
 //!
 //! ```no_run
 //! use mlua::Lua;
+//! use rucomfyui_mlua::{IntegrationConfig, module};
 //!
 //! # fn main() -> mlua::Result<()> {
 //! let lua = Lua::new();
 //!
-//! // Install the module
-//! let comfy = rucomfyui_mlua::module(&lua)?;
+//! // Install the module with all features enabled
+//! let config = IntegrationConfig::all();
+//! let comfy = module(&lua, &config)?;
 //! lua.globals().set("comfy", comfy)?;
 //!
 //! // Use from Lua
@@ -40,7 +42,7 @@
 //!         }
 //!     )
 //!
-//!     local result = client:queue(g)
+//!     local result = client:easy_queue(g)
 //!     for i, image in ipairs(result[preview].images) do
 //!         -- image is raw bytes
 //!     end
@@ -48,13 +50,62 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! # Configuration
+//!
+//! Use [`IntegrationConfig`] to control which functionality is exposed to Lua:
+//!
+//! ```no_run
+//! use rucomfyui_mlua::{ClientConfig, IntegrationConfig};
+//!
+//! // All methods enabled (default for IntegrationConfig::all())
+//! let full_config = IntegrationConfig::all();
+//!
+//! // Read-only access
+//! let readonly_config = IntegrationConfig {
+//!     client: ClientConfig::read_only(),
+//! };
+//!
+//! // Custom configuration
+//! let custom_config = IntegrationConfig {
+//!     client: ClientConfig {
+//!         get_object_info: true,
+//!         queue: true,
+//!         easy_queue: true,
+//!         ..ClientConfig::none()
+//!     },
+//! };
+//! ```
+//!
+//! # Creating Clients from Existing rucomfyui::Client
+//!
+//! If you already have a configured [`rucomfyui::Client`], you can wrap it:
+//!
+//! ```no_run
+//! use mlua::Lua;
+//! use rucomfyui_mlua::{ClientConfig, create_client_userdata};
+//!
+//! # fn main() -> mlua::Result<()> {
+//! let lua = Lua::new();
+//!
+//! // Create a pre-configured rucomfyui client
+//! let rust_client = rucomfyui::Client::new("http://127.0.0.1:8188");
+//!
+//! // Wrap it as a Lua userdata
+//! let lua_client = create_client_userdata(&lua, rust_client, ClientConfig::all())?;
+//! lua.globals().set("client", lua_client)?;
+//! # Ok(())
+//! # }
+//! ```
 
 mod client;
+mod config;
 mod conversion;
 mod error;
 mod graph;
 mod node_output;
 
+pub use config::{ClientConfig, IntegrationConfig};
 pub use error::Error;
 
 use mlua::{Lua, Result, Table};
@@ -64,23 +115,33 @@ use mlua::{Lua, Result, Table};
 /// This returns a table containing the module's functions and types.
 /// The integrator can place this table wherever they like in the Lua environment.
 ///
+/// # Arguments
+///
+/// * `lua` - The Lua state
+/// * `config` - Configuration controlling which features are available
+///
 /// # Example
 ///
 /// ```no_run
 /// use mlua::Lua;
+/// use rucomfyui_mlua::{IntegrationConfig, module};
 ///
 /// let lua = Lua::new();
-/// let comfy = rucomfyui_mlua::module(&lua)?;
+/// let config = IntegrationConfig::all();
+/// let comfy = module(&lua, &config)?;
 /// lua.globals().set("comfy", comfy)?;
 /// # Ok::<(), mlua::Error>(())
 /// ```
-pub fn module(lua: &Lua) -> Result<Table> {
+pub fn module(lua: &Lua, config: &IntegrationConfig) -> Result<Table> {
     let exports = lua.create_table()?;
+    let client_config = config.client.clone();
 
     // comfy.client(url) -> Client
     exports.set(
         "client",
-        lua.create_function(|lua, url: String| client::Client::new(lua, url))?,
+        lua.create_function(move |lua, url: String| {
+            client::Client::new(lua, url, client_config.clone())
+        })?,
     )?;
 
     // comfy.graph(object_info) -> Graph
@@ -90,4 +151,35 @@ pub fn module(lua: &Lua) -> Result<Table> {
     )?;
 
     Ok(exports)
+}
+
+/// Create a Lua userdata from an existing rucomfyui::Client.
+///
+/// This allows Rust integrators to pass in a pre-configured client
+/// rather than having Lua create one from a URL.
+///
+/// # Arguments
+///
+/// * `lua` - The Lua state
+/// * `client` - An existing rucomfyui::Client
+/// * `config` - Configuration controlling which methods are available
+///
+/// # Example
+///
+/// ```no_run
+/// use mlua::Lua;
+/// use rucomfyui_mlua::{ClientConfig, create_client_userdata};
+///
+/// let lua = Lua::new();
+/// let rust_client = rucomfyui::Client::new("http://127.0.0.1:8188");
+/// let lua_client = create_client_userdata(&lua, rust_client, ClientConfig::execute())?;
+/// lua.globals().set("my_client", lua_client)?;
+/// # Ok::<(), mlua::Error>(())
+/// ```
+pub fn create_client_userdata(
+    lua: &Lua,
+    client: rucomfyui::Client,
+    config: ClientConfig,
+) -> Result<mlua::AnyUserData> {
+    lua.create_userdata(client::Client::from_existing(client, config))
 }

--- a/crates/rucomfyui_mlua/src/node_output.rs
+++ b/crates/rucomfyui_mlua/src/node_output.rs
@@ -101,17 +101,6 @@ pub enum NodeOutputValue {
     Multiple(NodeOutputs),
 }
 
-impl NodeOutputValue {
-    /// Get the node ID.
-    #[allow(dead_code)]
-    pub fn node_id(&self) -> WorkflowNodeId {
-        match self {
-            Self::Single(o) => o.node_id,
-            Self::Multiple(o) => o.node_id,
-        }
-    }
-}
-
 impl IntoLua for NodeOutputValue {
     fn into_lua(self, lua: &Lua) -> LuaResult<LuaValue> {
         match self {

--- a/crates/rucomfyui_mlua/src/node_output.rs
+++ b/crates/rucomfyui_mlua/src/node_output.rs
@@ -1,0 +1,122 @@
+//! Node output types for Lua.
+//!
+//! These types represent the outputs of ComfyUI nodes and can be used
+//! as inputs to other nodes.
+
+use mlua::prelude::*;
+use rucomfyui::workflow::WorkflowNodeId;
+use std::collections::HashMap;
+
+/// A single output from a node.
+///
+/// This represents a specific output slot from a node and can be used
+/// as an input to another node.
+#[derive(Debug, Clone, Copy)]
+pub struct NodeOutput {
+    /// The node ID that produced this output.
+    pub node_id: WorkflowNodeId,
+    /// The output slot index.
+    pub slot: u32,
+}
+
+impl NodeOutput {
+    /// Create a new node output.
+    pub fn new(node_id: WorkflowNodeId, slot: u32) -> Self {
+        Self { node_id, slot }
+    }
+}
+
+impl LuaUserData for NodeOutput {
+    fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
+        methods.add_meta_method(LuaMetaMethod::ToString, |_, this, ()| {
+            Ok(format!("NodeOutput({}, slot={})", this.node_id, this.slot))
+        });
+    }
+}
+
+/// Multiple outputs from a node, accessible by name.
+///
+/// For nodes with multiple outputs (like CheckpointLoaderSimple which outputs
+/// model, clip, and vae), this provides named access to each output.
+#[derive(Debug, Clone)]
+pub struct NodeOutputs {
+    /// The node ID that produced these outputs.
+    pub node_id: WorkflowNodeId,
+    /// Map from output name to slot index.
+    pub outputs: HashMap<String, u32>,
+}
+
+impl NodeOutputs {
+    /// Create new node outputs.
+    pub fn new(node_id: WorkflowNodeId, outputs: HashMap<String, u32>) -> Self {
+        Self { node_id, outputs }
+    }
+
+    /// Get a specific output by name.
+    pub fn get(&self, name: &str) -> Option<NodeOutput> {
+        self.outputs
+            .get(name)
+            .map(|&slot| NodeOutput::new(self.node_id, slot))
+    }
+}
+
+impl LuaUserData for NodeOutputs {
+    fn add_fields<F: LuaUserDataFields<Self>>(fields: &mut F) {
+        // Expose node_id for result lookup
+        fields.add_field_method_get("_node_id", |_, this| Ok(this.node_id.0));
+    }
+
+    fn add_methods<M: LuaUserDataMethods<Self>>(methods: &mut M) {
+        methods.add_meta_method(LuaMetaMethod::ToString, |_, this, ()| {
+            let outputs: Vec<_> = this.outputs.keys().collect();
+            Ok(format!(
+                "NodeOutputs({}, outputs={:?})",
+                this.node_id, outputs
+            ))
+        });
+
+        // Allow indexing by output name: node_outputs.model, node_outputs.clip, etc.
+        methods.add_meta_method(LuaMetaMethod::Index, |lua, this, key: String| {
+            if key == "_node_id" {
+                return Ok(LuaValue::Integer(this.node_id.0 as i64));
+            }
+
+            match this.get(&key) {
+                Some(output) => Ok(LuaValue::UserData(lua.create_userdata(output)?)),
+                None => Ok(LuaValue::Nil),
+            }
+        });
+    }
+}
+
+/// Either a single output or multiple outputs.
+///
+/// This is returned by node constructors - single-output nodes return
+/// a NodeOutput directly, while multi-output nodes return NodeOutputs.
+#[derive(Debug, Clone)]
+pub enum NodeOutputValue {
+    /// A single output.
+    Single(NodeOutput),
+    /// Multiple named outputs.
+    Multiple(NodeOutputs),
+}
+
+impl NodeOutputValue {
+    /// Get the node ID.
+    #[allow(dead_code)]
+    pub fn node_id(&self) -> WorkflowNodeId {
+        match self {
+            Self::Single(o) => o.node_id,
+            Self::Multiple(o) => o.node_id,
+        }
+    }
+}
+
+impl IntoLua for NodeOutputValue {
+    fn into_lua(self, lua: &Lua) -> LuaResult<LuaValue> {
+        match self {
+            Self::Single(output) => Ok(LuaValue::UserData(lua.create_userdata(output)?)),
+            Self::Multiple(outputs) => Ok(LuaValue::UserData(lua.create_userdata(outputs)?)),
+        }
+    }
+}


### PR DESCRIPTION
Add a new crate that provides a fluent Lua API for building and executing ComfyUI workflows through mlua. Key features:

- Graph builder with dynamic node constructors from ObjectInfo
- Full Client wrapper exposing all rucomfyui operations:
  - Object info retrieval
  - Queue operations (queue, easy_queue, get_queue, interrupt, etc.)
  - History operations (get_history, clear_history, etc.)
  - Model operations (get_model_categories, get_models)
  - System operations (system_stats, free)
  - Upload support
- NodeOutput/NodeOutputs types for type-safe node connections
- Support for both positional and named arguments in node constructors

Example usage:
```lua
local comfy = rucomfyui_mlua.module(lua)
local client = comfy.client("http://127.0.0.1:8188")
local object_info = client:get_object_info()
local g = comfy.graph(object_info)

local c = g:CheckpointLoaderSimple("model.safetensors")
local preview = g:PreviewImage(g:VAEDecode {
    vae = c.vae,
    samples = g:KSampler { model = c.model, ... }
})

local result = client:easy_queue(g)
```