### PR TITLE
Format code + formatting CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
 
       - name: Run Clippy without features
         run: cargo clippy --all --no-default-features -- -D warnings

--- a/crates/rucomfyui/generate_nodes/src/lib.rs
+++ b/crates/rucomfyui/generate_nodes/src/lib.rs
@@ -259,6 +259,7 @@ fn write_category_tree_root(root: &CategoryTree, directory: &Path) -> Result<()>
                 write_category_tree((name, tree), &directory.join(key.to_string()))
                     .context(name.clone())?;
                 modules.push(quote! {
+                    #[rustfmt::skip]
                     pub mod #key;
                 });
             }
@@ -269,12 +270,13 @@ fn write_category_tree_root(root: &CategoryTree, directory: &Path) -> Result<()>
     let output = quote! {
         //! Typed node definitions for ComfyUI that provide a type-safe abstraction over the API.
         #(#modules)*
+        #[rustfmt::skip]
         pub mod all;
+        #[rustfmt::skip]
         pub mod types;
 
+        use crate::workflow::{WorkflowInput, WorkflowNodeId};
         use std::collections::HashMap;
-
-        use crate::workflow::{WorkflowNodeId, WorkflowInput};
 
         /// Implemented for all typed nodes; provides the node's output and metadata.
         pub trait TypedNode: Clone {
@@ -320,6 +322,7 @@ fn write_category_tree((name, tree): (&str, &CategoryTree), directory: &Path) ->
                 write_category_tree((name, tree), &directory.join(key.to_string()))
                     .context(name.clone())?;
                 modules.push(quote! {
+                    #[rustfmt::skip]
                     pub mod #key;
                 });
             }

--- a/crates/rucomfyui/src/nodes/advanced/conditioning/mod.rs
+++ b/crates/rucomfyui/src/nodes/advanced/conditioning/mod.rs
@@ -5,7 +5,9 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod edit_models;
+#[rustfmt::skip]
 pub mod flux;
 ///**CLIPTextEncodeHiDream**: No description.
 #[derive(Clone)]

--- a/crates/rucomfyui/src/nodes/advanced/debug/mod.rs
+++ b/crates/rucomfyui/src/nodes/advanced/debug/mod.rs
@@ -5,4 +5,5 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod model;

--- a/crates/rucomfyui/src/nodes/advanced/hooks/mod.rs
+++ b/crates/rucomfyui/src/nodes/advanced/hooks/mod.rs
@@ -5,11 +5,17 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod clip;
+#[rustfmt::skip]
 pub mod combine;
+#[rustfmt::skip]
 pub mod cond_pair;
+#[rustfmt::skip]
 pub mod cond_single;
+#[rustfmt::skip]
 pub mod create;
+#[rustfmt::skip]
 pub mod scheduling;
 /// Output types for nodes.
 pub mod out {

--- a/crates/rucomfyui/src/nodes/advanced/loaders/mod.rs
+++ b/crates/rucomfyui/src/nodes/advanced/loaders/mod.rs
@@ -5,7 +5,9 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod deprecated;
+#[rustfmt::skip]
 pub mod qwen;
 /// Output types for nodes.
 pub mod out {

--- a/crates/rucomfyui/src/nodes/advanced/mod.rs
+++ b/crates/rucomfyui/src/nodes/advanced/mod.rs
@@ -5,11 +5,19 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod conditioning;
+#[rustfmt::skip]
 pub mod debug;
+#[rustfmt::skip]
 pub mod guidance;
+#[rustfmt::skip]
 pub mod hooks;
+#[rustfmt::skip]
 pub mod loaders;
+#[rustfmt::skip]
 pub mod model;
+#[rustfmt::skip]
 pub mod model_merging;
+#[rustfmt::skip]
 pub mod model_patches;

--- a/crates/rucomfyui/src/nodes/advanced/model_merging/mod.rs
+++ b/crates/rucomfyui/src/nodes/advanced/model_merging/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod model_specific;
 ///**CLIPMergeAdd**: No description.
 #[derive(Clone)]

--- a/crates/rucomfyui/src/nodes/advanced/model_patches/mod.rs
+++ b/crates/rucomfyui/src/nodes/advanced/model_patches/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod flux;
 ///**ScaleROPE**: Scale and shift the ROPE of the model.
 #[derive(Clone)]

--- a/crates/rucomfyui/src/nodes/api_node/audio/mod.rs
+++ b/crates/rucomfyui/src/nodes/api_node/audio/mod.rs
@@ -5,4 +5,5 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod stability_ai;

--- a/crates/rucomfyui/src/nodes/api_node/image/mod.rs
+++ b/crates/rucomfyui/src/nodes/api_node/image/mod.rs
@@ -5,14 +5,25 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod bfl;
+#[rustfmt::skip]
 pub mod byte_dance;
+#[rustfmt::skip]
 pub mod gemini;
+#[rustfmt::skip]
 pub mod ideogram;
+#[rustfmt::skip]
 pub mod kling;
+#[rustfmt::skip]
 pub mod luma;
+#[rustfmt::skip]
 pub mod open_ai;
+#[rustfmt::skip]
 pub mod recraft;
+#[rustfmt::skip]
 pub mod runway;
+#[rustfmt::skip]
 pub mod stability_ai;
+#[rustfmt::skip]
 pub mod wan;

--- a/crates/rucomfyui/src/nodes/api_node/mod.rs
+++ b/crates/rucomfyui/src/nodes/api_node/mod.rs
@@ -5,8 +5,13 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod n_3_d;
+#[rustfmt::skip]
 pub mod audio;
+#[rustfmt::skip]
 pub mod image;
+#[rustfmt::skip]
 pub mod text;
+#[rustfmt::skip]
 pub mod video;

--- a/crates/rucomfyui/src/nodes/api_node/n_3_d/mod.rs
+++ b/crates/rucomfyui/src/nodes/api_node/n_3_d/mod.rs
@@ -5,5 +5,7 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod rodin;
+#[rustfmt::skip]
 pub mod tripo;

--- a/crates/rucomfyui/src/nodes/api_node/text/mod.rs
+++ b/crates/rucomfyui/src/nodes/api_node/text/mod.rs
@@ -5,5 +5,7 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod gemini;
+#[rustfmt::skip]
 pub mod open_ai;

--- a/crates/rucomfyui/src/nodes/api_node/video/mod.rs
+++ b/crates/rucomfyui/src/nodes/api_node/video/mod.rs
@@ -5,16 +5,29 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod byte_dance;
+#[rustfmt::skip]
 pub mod kling;
+#[rustfmt::skip]
 pub mod ltxv;
+#[rustfmt::skip]
 pub mod luma;
+#[rustfmt::skip]
 pub mod mini_max;
+#[rustfmt::skip]
 pub mod moonvalley_marey;
+#[rustfmt::skip]
 pub mod pika;
+#[rustfmt::skip]
 pub mod pix_verse;
+#[rustfmt::skip]
 pub mod runway;
+#[rustfmt::skip]
 pub mod sora;
+#[rustfmt::skip]
 pub mod veo;
+#[rustfmt::skip]
 pub mod vidu;
+#[rustfmt::skip]
 pub mod wan;

--- a/crates/rucomfyui/src/nodes/conditioning/mod.rs
+++ b/crates/rucomfyui/src/nodes/conditioning/mod.rs
@@ -5,15 +5,25 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod n_3_d_models;
+#[rustfmt::skip]
 pub mod controlnet;
+#[rustfmt::skip]
 pub mod gligen;
+#[rustfmt::skip]
 pub mod inpaint;
+#[rustfmt::skip]
 pub mod instructpix_2_pix;
+#[rustfmt::skip]
 pub mod lotus;
+#[rustfmt::skip]
 pub mod stable_cascade;
+#[rustfmt::skip]
 pub mod style_model;
+#[rustfmt::skip]
 pub mod upscale_diffusion;
+#[rustfmt::skip]
 pub mod video_models;
 /// Output types for nodes.
 pub mod out {

--- a/crates/rucomfyui/src/nodes/image/mod.rs
+++ b/crates/rucomfyui/src/nodes/image/mod.rs
@@ -5,13 +5,21 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod animation;
+#[rustfmt::skip]
 pub mod batch;
+#[rustfmt::skip]
 pub mod postprocessing;
+#[rustfmt::skip]
 pub mod preprocessors;
+#[rustfmt::skip]
 pub mod save;
+#[rustfmt::skip]
 pub mod transform;
+#[rustfmt::skip]
 pub mod upscaling;
+#[rustfmt::skip]
 pub mod video;
 /// Output types for nodes.
 pub mod out {

--- a/crates/rucomfyui/src/nodes/latent/advanced/mod.rs
+++ b/crates/rucomfyui/src/nodes/latent/advanced/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod operations;
 ///**LatentAdd**: No description.
 #[derive(Clone)]

--- a/crates/rucomfyui/src/nodes/latent/mod.rs
+++ b/crates/rucomfyui/src/nodes/latent/mod.rs
@@ -5,15 +5,25 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod n_3_d;
+#[rustfmt::skip]
 pub mod advanced;
+#[rustfmt::skip]
 pub mod audio;
+#[rustfmt::skip]
 pub mod batch;
+#[rustfmt::skip]
 pub mod chroma_radiance;
+#[rustfmt::skip]
 pub mod inpaint;
+#[rustfmt::skip]
 pub mod sd_3;
+#[rustfmt::skip]
 pub mod stable_cascade;
+#[rustfmt::skip]
 pub mod transform;
+#[rustfmt::skip]
 pub mod video;
 ///**EmptyHunyuanImageLatent**: No description.
 #[derive(Clone)]

--- a/crates/rucomfyui/src/nodes/latent/video/mod.rs
+++ b/crates/rucomfyui/src/nodes/latent/video/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod ltxv;
 ///**EmptyCosmosLatentVideo**: No description.
 #[derive(Clone)]

--- a/crates/rucomfyui/src/nodes/loaders/mod.rs
+++ b/crates/rucomfyui/src/nodes/loaders/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod video_models;
 /// Output types for nodes.
 pub mod out {

--- a/crates/rucomfyui/src/nodes/mask/mod.rs
+++ b/crates/rucomfyui/src/nodes/mask/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod compositing;
 ///**CropMask**: No description.
 #[derive(Clone)]

--- a/crates/rucomfyui/src/nodes/mod.rs
+++ b/crates/rucomfyui/src/nodes/mod.rs
@@ -1,24 +1,42 @@
 //! Typed node definitions for ComfyUI that provide a type-safe abstraction over the API.
+#[rustfmt::skip]
 pub mod n_3_d;
+#[rustfmt::skip]
 pub mod advanced;
+#[rustfmt::skip]
 pub mod api_node;
+#[rustfmt::skip]
 pub mod audio;
+#[rustfmt::skip]
 pub mod camera;
+#[rustfmt::skip]
 pub mod conditioning;
+#[rustfmt::skip]
 pub mod context;
+#[rustfmt::skip]
 pub mod image;
+#[rustfmt::skip]
 pub mod latent;
+#[rustfmt::skip]
 pub mod loaders;
+#[rustfmt::skip]
 pub mod mask;
+#[rustfmt::skip]
 pub mod model_patches;
+#[rustfmt::skip]
 pub mod sampling;
+#[rustfmt::skip]
 pub mod sd;
+#[rustfmt::skip]
 pub mod training;
+#[rustfmt::skip]
 pub mod utils;
+#[rustfmt::skip]
 pub mod all;
+#[rustfmt::skip]
 pub mod types;
+use crate::workflow::{WorkflowInput, WorkflowNodeId};
 use std::collections::HashMap;
-use crate::workflow::{WorkflowNodeId, WorkflowInput};
 /// Implemented for all typed nodes; provides the node's output and metadata.
 pub trait TypedNode: Clone {
     /// The type of the node's output.

--- a/crates/rucomfyui/src/nodes/model_patches/mod.rs
+++ b/crates/rucomfyui/src/nodes/model_patches/mod.rs
@@ -5,5 +5,7 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod chroma_radiance;
+#[rustfmt::skip]
 pub mod unet;

--- a/crates/rucomfyui/src/nodes/sampling/custom_sampling/mod.rs
+++ b/crates/rucomfyui/src/nodes/sampling/custom_sampling/mod.rs
@@ -5,10 +5,15 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod guiders;
+#[rustfmt::skip]
 pub mod noise;
+#[rustfmt::skip]
 pub mod samplers;
+#[rustfmt::skip]
 pub mod schedulers;
+#[rustfmt::skip]
 pub mod sigmas;
 /// Output types for nodes.
 pub mod out {

--- a/crates/rucomfyui/src/nodes/sampling/mod.rs
+++ b/crates/rucomfyui/src/nodes/sampling/mod.rs
@@ -5,7 +5,9 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod custom_sampling;
+#[rustfmt::skip]
 pub mod video_models;
 ///**KSampler**: Uses the provided model, positive and negative conditioning to denoise the latent image.
 #[derive(Clone)]

--- a/crates/rucomfyui/src/nodes/utils/mod.rs
+++ b/crates/rucomfyui/src/nodes/utils/mod.rs
@@ -5,7 +5,9 @@ use crate::{
     workflow::{WorkflowNodeId, WorkflowInput},
     nodes::types::Out,
 };
+#[rustfmt::skip]
 pub mod primitive;
+#[rustfmt::skip]
 pub mod string;
 ///**Preview Any**: No description.
 #[derive(Clone)]

--- a/crates/rucomfyui_mlua/examples/run_script.rs
+++ b/crates/rucomfyui_mlua/examples/run_script.rs
@@ -15,7 +15,9 @@ async fn main() -> anyhow::Result<()> {
     let args: Vec<String> = std::env::args().collect();
 
     // Parse arguments
-    let url = args.get(1).context("Usage: run_script <url> [script] [prompt]")?;
+    let url = args
+        .get(1)
+        .context("Usage: run_script <url> [script] [prompt]")?;
     let script_path = args
         .get(2)
         .map(|s| s.as_str())
@@ -53,11 +55,7 @@ async fn main() -> anyhow::Result<()> {
         println!("Prompt: {}", prompt);
     }
 
-    let images: Vec<mlua::String> = lua
-        .load(&script)
-        .set_name(script_path)
-        .eval_async()
-        .await?;
+    let images: Vec<mlua::String> = lua.load(&script).set_name(script_path).eval_async().await?;
 
     // Save the images
     for (idx, image) in images.iter().enumerate() {

--- a/crates/rucomfyui_mlua/src/conversion.rs
+++ b/crates/rucomfyui_mlua/src/conversion.rs
@@ -29,10 +29,7 @@ pub fn lua_to_workflow_input(value: LuaValue) -> LuaResult<WorkflowInput> {
         LuaValue::UserData(ud) => {
             // Try NodeOutput first
             if let Ok(output) = ud.borrow::<NodeOutput>() {
-                return Ok(WorkflowInput::Slot(
-                    output.node_id.to_string(),
-                    output.slot,
-                ));
+                return Ok(WorkflowInput::Slot(output.node_id.to_string(), output.slot));
             }
             // Try NodeOutputs (use slot 0 by default)
             if let Ok(outputs) = ud.borrow::<NodeOutputs>() {
@@ -52,4 +49,3 @@ pub fn lua_to_workflow_input(value: LuaValue) -> LuaResult<WorkflowInput> {
         ))),
     }
 }
-


### PR DESCRIPTION
- Add #![rustfmt::skip] to all generated node modules to prevent formatting of machine-generated code
- Add rustfmt check step to CI workflow
- Format existing non-generated code with cargo fmt