### PR TITLE
Build API workflow to Rust/Lua converter

### DIFF
--- a/bin/rucomfyui_node_graph_demo/Cargo.toml
+++ b/bin/rucomfyui_node_graph_demo/Cargo.toml
@@ -12,6 +12,7 @@ web-time = { workspace = true }
 # We don't need the typed nodes, so disable them
 rucomfyui = { path = "../../crates/rucomfyui", default-features = false }
 rucomfyui_node_graph = { path = "../../crates/rucomfyui_node_graph", default-features = false }
+rucomfyui_workflow_converter = { path = "../../crates/rucomfyui_workflow_converter", features = ["lua", "rust"] }
 
 eframe = { version = "0.29", features = ["persistence"] }
 egui_extras = { version = "0.29", features = ["all_loaders"] }

--- a/bin/rucomfyui_node_graph_demo/src/main.rs
+++ b/bin/rucomfyui_node_graph_demo/src/main.rs
@@ -861,16 +861,18 @@ impl Application {
                 return;
             }
         };
-        let lua_code =
-            match rucomfyui_workflow_converter::convert_to_lua(&workflow_json, &graph.object_info) {
-                Ok(code) => code,
-                Err(err) => {
-                    self.async_output_tx
-                        .send(AsyncResponse::error("Copy Lua", err))
-                        .unwrap();
-                    return;
-                }
-            };
+        let lua_code = match rucomfyui_workflow_converter::convert_to_lua(
+            &workflow_json,
+            &graph.object_info,
+        ) {
+            Ok(code) => code,
+            Err(err) => {
+                self.async_output_tx
+                    .send(AsyncResponse::error("Copy Lua", err))
+                    .unwrap();
+                return;
+            }
+        };
 
         ctx.copy_text(lua_code);
     }

--- a/bin/rucomfyui_node_graph_demo/src/main.rs
+++ b/bin/rucomfyui_node_graph_demo/src/main.rs
@@ -245,6 +245,13 @@ impl eframe::App for Application {
                         if ui.button("Save API workflow").clicked() {
                             self.request_api_save();
                         }
+                        ui.separator();
+                        if ui.button("Copy as Lua").clicked() {
+                            self.copy_as_lua(ui.ctx());
+                        }
+                        if ui.button("Copy as Rust").clicked() {
+                            self.copy_as_rust(ui.ctx());
+                        }
                     });
                     if ui.button("System stats").clicked() {
                         self.request_system_stats();
@@ -834,6 +841,71 @@ impl Application {
                 tx.send(AsyncResponse::error("Save", err)).unwrap();
             }
         });
+    }
+    /// Copy the current graph as Lua code to the clipboard.
+    fn copy_as_lua(&mut self, ctx: &egui::Context) {
+        let Some(graph) = self.graph.as_ref() else {
+            self.async_output_tx
+                .send(AsyncResponse::error("Copy Lua", "No graph to copy"))
+                .unwrap();
+            return;
+        };
+
+        let workflow = graph.save_api_workflow();
+        let workflow_json = match workflow.to_json() {
+            Ok(json) => json,
+            Err(err) => {
+                self.async_output_tx
+                    .send(AsyncResponse::error("Copy Lua", err))
+                    .unwrap();
+                return;
+            }
+        };
+        let lua_code =
+            match rucomfyui_workflow_converter::convert_to_lua(&workflow_json, &graph.object_info) {
+                Ok(code) => code,
+                Err(err) => {
+                    self.async_output_tx
+                        .send(AsyncResponse::error("Copy Lua", err))
+                        .unwrap();
+                    return;
+                }
+            };
+
+        ctx.copy_text(lua_code);
+    }
+    /// Copy the current graph as Rust code to the clipboard.
+    fn copy_as_rust(&mut self, ctx: &egui::Context) {
+        let Some(graph) = self.graph.as_ref() else {
+            self.async_output_tx
+                .send(AsyncResponse::error("Copy Rust", "No graph to copy"))
+                .unwrap();
+            return;
+        };
+
+        let workflow = graph.save_api_workflow();
+        let workflow_json = match workflow.to_json() {
+            Ok(json) => json,
+            Err(err) => {
+                self.async_output_tx
+                    .send(AsyncResponse::error("Copy Rust", err))
+                    .unwrap();
+                return;
+            }
+        };
+        let rust_code =
+            match rucomfyui_workflow_converter::convert_to_rust(&workflow_json, &graph.object_info)
+            {
+                Ok(code) => code,
+                Err(err) => {
+                    self.async_output_tx
+                        .send(AsyncResponse::error("Copy Rust", err))
+                        .unwrap();
+                    return;
+                }
+            };
+
+        ctx.copy_text(rust_code);
     }
 
     /// Connect to ComfyUI at the address specified in [`Self::comfyui_address`].

--- a/bin/rucomfyui_workflow_converter/Cargo.toml
+++ b/bin/rucomfyui_workflow_converter/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rucomfyui_workflow_converter_cli"
+version = "0.1.0"
+edition = "2021"
+description = "CLI tool to convert ComfyUI API workflows to Rust or Lua code"
+
+[dependencies]
+anyhow = { workspace = true }
+rucomfyui = { path = "../../crates/rucomfyui" }
+rucomfyui_workflow_converter = { path = "../../crates/rucomfyui_workflow_converter" }
+serde_json = { workspace = true }

--- a/bin/rucomfyui_workflow_converter/Cargo.toml
+++ b/bin/rucomfyui_workflow_converter/Cargo.toml
@@ -6,6 +6,7 @@ description = "CLI tool to convert ComfyUI API workflows to Rust or Lua code"
 
 [dependencies]
 anyhow = { workspace = true }
+clap = { version = "4", features = ["derive"] }
 rucomfyui = { path = "../../crates/rucomfyui" }
 rucomfyui_workflow_converter = { path = "../../crates/rucomfyui_workflow_converter" }
 serde_json = { workspace = true }

--- a/bin/rucomfyui_workflow_converter/src/main.rs
+++ b/bin/rucomfyui_workflow_converter/src/main.rs
@@ -4,8 +4,8 @@ use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 use rucomfyui::object_info::ObjectInfo;
 use rucomfyui_workflow_converter::{
-    convert_to_lua_with_config, convert_to_rust_with_config, convert_to_rust_with_object_info,
-    LuaGeneratorConfig, RustGeneratorConfig,
+    convert_to_lua_with_object_info, convert_to_rust_with_object_info, LuaGeneratorConfig,
+    RustGeneratorConfig,
 };
 use std::fs;
 use std::io::{self, Write};
@@ -22,20 +22,24 @@ enum OutputFormat {
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 #[command(after_help = "EXAMPLES:
-    # Convert to Rust using dynamic nodes
-    rucomfyui_workflow_converter workflow.json
+    # Convert to Rust with typed nodes
+    rucomfyui_workflow_converter workflow.json --object-info object_info.json
 
-    # Convert to Rust with typed nodes using object_info
+    # Convert to Rust with full wrapper function
     rucomfyui_workflow_converter workflow.json --object-info object_info.json --complete
 
     # Convert to Lua with full boilerplate
-    rucomfyui_workflow_converter workflow.json --format lua --complete
+    rucomfyui_workflow_converter workflow.json --object-info object_info.json --format lua --complete
 
     # Output to file
-    rucomfyui_workflow_converter workflow.json --complete -o workflow.rs")]
+    rucomfyui_workflow_converter workflow.json --object-info object_info.json --complete -o workflow.rs")]
 struct Args {
     /// Path to the ComfyUI API workflow JSON file
     input: PathBuf,
+
+    /// Path to object_info.json for type-aware code generation
+    #[arg(long, value_name = "FILE")]
+    object_info: PathBuf,
 
     /// Output format
     #[arg(short, long, value_enum, default_value_t = OutputFormat::Rust)]
@@ -44,10 +48,6 @@ struct Args {
     /// Include boilerplate/wrapper code
     #[arg(short, long)]
     complete: bool,
-
-    /// Path to object_info.json for typed Rust output (enables type-aware code generation)
-    #[arg(long, value_name = "FILE")]
-    object_info: Option<PathBuf>,
 
     /// Write to file instead of stdout
     #[arg(short, long, value_name = "FILE")]
@@ -61,6 +61,9 @@ fn main() -> Result<()> {
     let json = fs::read_to_string(&args.input)
         .with_context(|| format!("Failed to read input file: {}", args.input.display()))?;
 
+    // Load ObjectInfo
+    let object_info = load_object_info(&args.object_info)?;
+
     // Convert
     let output = match args.format {
         OutputFormat::Lua => {
@@ -69,7 +72,7 @@ fn main() -> Result<()> {
             } else {
                 LuaGeneratorConfig::snippet()
             };
-            convert_to_lua_with_config(&json, &config)?
+            convert_to_lua_with_object_info(&json, &object_info, &config)?
         }
         OutputFormat::Rust => {
             let config = if args.complete {
@@ -77,13 +80,7 @@ fn main() -> Result<()> {
             } else {
                 RustGeneratorConfig::snippet()
             };
-
-            if let Some(oi_path) = &args.object_info {
-                let object_info = load_object_info(oi_path)?;
-                convert_to_rust_with_object_info(&json, &object_info, &config)?
-            } else {
-                convert_to_rust_with_config(&json, &config)?
-            }
+            convert_to_rust_with_object_info(&json, &object_info, &config)?
         }
     };
 

--- a/bin/rucomfyui_workflow_converter/src/main.rs
+++ b/bin/rucomfyui_workflow_converter/src/main.rs
@@ -1,17 +1,7 @@
 //! CLI tool to convert ComfyUI API workflows to Rust or Lua code.
-//!
-//! Usage:
-//!   rucomfyui_workflow_converter <input.json> [OPTIONS]
-//!
-//! Options:
-//!   --rust           Output Rust code (default)
-//!   --lua            Output Lua code
-//!   --complete       Include boilerplate/wrapper code
-//!   --object-info    Path to object_info.json for typed Rust output
-//!   --output, -o     Write to file instead of stdout
-//!   --help           Show this help
 
 use anyhow::{Context, Result};
+use clap::{Parser, ValueEnum};
 use rucomfyui::object_info::ObjectInfo;
 use rucomfyui_workflow_converter::{
     convert_to_lua_with_config, convert_to_rust_with_config, convert_to_rust_with_object_info,
@@ -19,104 +9,19 @@ use rucomfyui_workflow_converter::{
 };
 use std::fs;
 use std::io::{self, Write};
+use std::path::PathBuf;
 
-fn main() -> Result<()> {
-    let args: Vec<String> = std::env::args().collect();
-
-    if args.len() < 2 || args.iter().any(|a| a == "--help" || a == "-h") {
-        print_help();
-        return Ok(());
-    }
-
-    let input_file = &args[1];
-    let use_lua = args.iter().any(|a| a == "--lua");
-    let complete = args.iter().any(|a| a == "--complete");
-
-    // Find output file if specified
-    let output_file = args
-        .iter()
-        .position(|a| a == "--output" || a == "-o")
-        .and_then(|i| args.get(i + 1))
-        .map(|s| s.as_str());
-
-    // Find object_info file if specified
-    let object_info_file = args
-        .iter()
-        .position(|a| a == "--object-info")
-        .and_then(|i| args.get(i + 1))
-        .map(|s| s.as_str());
-
-    // Read input
-    let json = fs::read_to_string(input_file)
-        .with_context(|| format!("Failed to read input file: {}", input_file))?;
-
-    // Convert
-    let output = if use_lua {
-        let config = if complete {
-            LuaGeneratorConfig::complete()
-        } else {
-            LuaGeneratorConfig::snippet()
-        };
-        convert_to_lua_with_config(&json, &config)?
-    } else {
-        let config = if complete {
-            RustGeneratorConfig::complete("workflow")
-        } else {
-            RustGeneratorConfig::snippet()
-        };
-
-        if let Some(oi_path) = object_info_file {
-            // Load ObjectInfo and use typed conversion
-            let object_info = load_object_info(oi_path)?;
-            convert_to_rust_with_object_info(&json, &object_info, &config)?
-        } else {
-            // Use dynamic conversion
-            convert_to_rust_with_config(&json, &config)?
-        }
-    };
-
-    // Write output
-    if let Some(output_path) = output_file {
-        fs::write(output_path, &output)
-            .with_context(|| format!("Failed to write output file: {}", output_path))?;
-        eprintln!("Wrote output to: {}", output_path);
-    } else {
-        io::stdout().write_all(output.as_bytes())?;
-    }
-
-    Ok(())
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+enum OutputFormat {
+    #[default]
+    Rust,
+    Lua,
 }
 
-fn load_object_info(path: &str) -> Result<ObjectInfo> {
-    let json = fs::read_to_string(path)
-        .with_context(|| format!("Failed to read object_info file: {}", path))?;
-
-    let objects: Vec<rucomfyui::object_info::Object> =
-        serde_json::from_str(&json).with_context(|| "Failed to parse object_info.json")?;
-
-    Ok(objects.into_iter().map(|o| (o.name.clone(), o)).collect())
-}
-
-fn print_help() {
-    eprintln!(
-        r#"rucomfyui_workflow_converter - Convert ComfyUI API workflows to Rust or Lua code
-
-USAGE:
-    rucomfyui_workflow_converter <input.json> [OPTIONS]
-
-ARGUMENTS:
-    <input.json>    Path to the ComfyUI API workflow JSON file
-
-OPTIONS:
-    --rust           Output Rust code (default)
-    --lua            Output Lua code
-    --complete       Include boilerplate/wrapper code
-    --object-info    Path to object_info.json for typed Rust output
-                     (enables type-aware code generation)
-    --output, -o     Write to file instead of stdout
-    --help, -h       Show this help
-
-EXAMPLES:
+/// Convert ComfyUI API workflows to Rust or Lua code
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+#[command(after_help = "EXAMPLES:
     # Convert to Rust using dynamic nodes
     rucomfyui_workflow_converter workflow.json
 
@@ -124,10 +29,82 @@ EXAMPLES:
     rucomfyui_workflow_converter workflow.json --object-info object_info.json --complete
 
     # Convert to Lua with full boilerplate
-    rucomfyui_workflow_converter workflow.json --lua --complete
+    rucomfyui_workflow_converter workflow.json --format lua --complete
 
     # Output to file
-    rucomfyui_workflow_converter workflow.json --complete -o workflow.rs
-"#
-    );
+    rucomfyui_workflow_converter workflow.json --complete -o workflow.rs")]
+struct Args {
+    /// Path to the ComfyUI API workflow JSON file
+    input: PathBuf,
+
+    /// Output format
+    #[arg(short, long, value_enum, default_value_t = OutputFormat::Rust)]
+    format: OutputFormat,
+
+    /// Include boilerplate/wrapper code
+    #[arg(short, long)]
+    complete: bool,
+
+    /// Path to object_info.json for typed Rust output (enables type-aware code generation)
+    #[arg(long, value_name = "FILE")]
+    object_info: Option<PathBuf>,
+
+    /// Write to file instead of stdout
+    #[arg(short, long, value_name = "FILE")]
+    output: Option<PathBuf>,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+
+    // Read input
+    let json = fs::read_to_string(&args.input)
+        .with_context(|| format!("Failed to read input file: {}", args.input.display()))?;
+
+    // Convert
+    let output = match args.format {
+        OutputFormat::Lua => {
+            let config = if args.complete {
+                LuaGeneratorConfig::complete()
+            } else {
+                LuaGeneratorConfig::snippet()
+            };
+            convert_to_lua_with_config(&json, &config)?
+        }
+        OutputFormat::Rust => {
+            let config = if args.complete {
+                RustGeneratorConfig::complete("workflow")
+            } else {
+                RustGeneratorConfig::snippet()
+            };
+
+            if let Some(oi_path) = &args.object_info {
+                let object_info = load_object_info(oi_path)?;
+                convert_to_rust_with_object_info(&json, &object_info, &config)?
+            } else {
+                convert_to_rust_with_config(&json, &config)?
+            }
+        }
+    };
+
+    // Write output
+    if let Some(output_path) = &args.output {
+        fs::write(output_path, &output)
+            .with_context(|| format!("Failed to write output file: {}", output_path.display()))?;
+        eprintln!("Wrote output to: {}", output_path.display());
+    } else {
+        io::stdout().write_all(output.as_bytes())?;
+    }
+
+    Ok(())
+}
+
+fn load_object_info(path: &PathBuf) -> Result<ObjectInfo> {
+    let json = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read object_info file: {}", path.display()))?;
+
+    let objects: Vec<rucomfyui::object_info::Object> =
+        serde_json::from_str(&json).with_context(|| "Failed to parse object_info.json")?;
+
+    Ok(objects.into_iter().map(|o| (o.name.clone(), o)).collect())
 }

--- a/bin/rucomfyui_workflow_converter/src/main.rs
+++ b/bin/rucomfyui_workflow_converter/src/main.rs
@@ -11,6 +11,10 @@ use std::fs;
 use std::io::{self, Write};
 use std::path::PathBuf;
 
+/// Bundled object_info.json from generate_nodes
+const BUNDLED_OBJECT_INFO: &str =
+    include_str!("../../../crates/rucomfyui/generate_nodes/object_info.json");
+
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
 enum OutputFormat {
     #[default]
@@ -22,24 +26,27 @@ enum OutputFormat {
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 #[command(after_help = "EXAMPLES:
-    # Convert to Rust with typed nodes
-    rucomfyui_workflow_converter workflow.json --object-info object_info.json
+    # Convert to Rust with typed nodes (uses bundled object_info)
+    rucomfyui_workflow_converter workflow.json
 
     # Convert to Rust with full wrapper function
-    rucomfyui_workflow_converter workflow.json --object-info object_info.json --complete
+    rucomfyui_workflow_converter workflow.json --complete
 
     # Convert to Lua with full boilerplate
-    rucomfyui_workflow_converter workflow.json --object-info object_info.json --format lua --complete
+    rucomfyui_workflow_converter workflow.json --format lua --complete
+
+    # Use custom object_info.json
+    rucomfyui_workflow_converter workflow.json --object-info custom_object_info.json
 
     # Output to file
-    rucomfyui_workflow_converter workflow.json --object-info object_info.json --complete -o workflow.rs")]
+    rucomfyui_workflow_converter workflow.json --complete -o workflow.rs")]
 struct Args {
     /// Path to the ComfyUI API workflow JSON file
     input: PathBuf,
 
-    /// Path to object_info.json for type-aware code generation
+    /// Path to object_info.json (uses bundled version if not specified)
     #[arg(long, value_name = "FILE")]
-    object_info: PathBuf,
+    object_info: Option<PathBuf>,
 
     /// Output format
     #[arg(short, long, value_enum, default_value_t = OutputFormat::Rust)]
@@ -61,8 +68,11 @@ fn main() -> Result<()> {
     let json = fs::read_to_string(&args.input)
         .with_context(|| format!("Failed to read input file: {}", args.input.display()))?;
 
-    // Load ObjectInfo
-    let object_info = load_object_info(&args.object_info)?;
+    // Load ObjectInfo (from file or bundled)
+    let object_info = match &args.object_info {
+        Some(path) => load_object_info_from_file(path)?,
+        None => load_bundled_object_info()?,
+    };
 
     // Convert
     let output = match args.format {
@@ -96,7 +106,14 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn load_object_info(path: &PathBuf) -> Result<ObjectInfo> {
+fn load_bundled_object_info() -> Result<ObjectInfo> {
+    let objects: Vec<rucomfyui::object_info::Object> =
+        serde_json::from_str(BUNDLED_OBJECT_INFO).context("Failed to parse bundled object_info")?;
+
+    Ok(objects.into_iter().map(|o| (o.name.clone(), o)).collect())
+}
+
+fn load_object_info_from_file(path: &PathBuf) -> Result<ObjectInfo> {
     let json = fs::read_to_string(path)
         .with_context(|| format!("Failed to read object_info file: {}", path.display()))?;
 

--- a/bin/rucomfyui_workflow_converter/src/main.rs
+++ b/bin/rucomfyui_workflow_converter/src/main.rs
@@ -1,0 +1,133 @@
+//! CLI tool to convert ComfyUI API workflows to Rust or Lua code.
+//!
+//! Usage:
+//!   rucomfyui_workflow_converter <input.json> [OPTIONS]
+//!
+//! Options:
+//!   --rust           Output Rust code (default)
+//!   --lua            Output Lua code
+//!   --complete       Include boilerplate/wrapper code
+//!   --object-info    Path to object_info.json for typed Rust output
+//!   --output, -o     Write to file instead of stdout
+//!   --help           Show this help
+
+use anyhow::{Context, Result};
+use rucomfyui::object_info::ObjectInfo;
+use rucomfyui_workflow_converter::{
+    convert_to_lua_with_config, convert_to_rust_with_config, convert_to_rust_with_object_info,
+    LuaGeneratorConfig, RustGeneratorConfig,
+};
+use std::fs;
+use std::io::{self, Write};
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.len() < 2 || args.iter().any(|a| a == "--help" || a == "-h") {
+        print_help();
+        return Ok(());
+    }
+
+    let input_file = &args[1];
+    let use_lua = args.iter().any(|a| a == "--lua");
+    let complete = args.iter().any(|a| a == "--complete");
+
+    // Find output file if specified
+    let output_file = args
+        .iter()
+        .position(|a| a == "--output" || a == "-o")
+        .and_then(|i| args.get(i + 1))
+        .map(|s| s.as_str());
+
+    // Find object_info file if specified
+    let object_info_file = args
+        .iter()
+        .position(|a| a == "--object-info")
+        .and_then(|i| args.get(i + 1))
+        .map(|s| s.as_str());
+
+    // Read input
+    let json = fs::read_to_string(input_file)
+        .with_context(|| format!("Failed to read input file: {}", input_file))?;
+
+    // Convert
+    let output = if use_lua {
+        let config = if complete {
+            LuaGeneratorConfig::complete()
+        } else {
+            LuaGeneratorConfig::snippet()
+        };
+        convert_to_lua_with_config(&json, &config)?
+    } else {
+        let config = if complete {
+            RustGeneratorConfig::complete("workflow")
+        } else {
+            RustGeneratorConfig::snippet()
+        };
+
+        if let Some(oi_path) = object_info_file {
+            // Load ObjectInfo and use typed conversion
+            let object_info = load_object_info(oi_path)?;
+            convert_to_rust_with_object_info(&json, &object_info, &config)?
+        } else {
+            // Use dynamic conversion
+            convert_to_rust_with_config(&json, &config)?
+        }
+    };
+
+    // Write output
+    if let Some(output_path) = output_file {
+        fs::write(output_path, &output)
+            .with_context(|| format!("Failed to write output file: {}", output_path))?;
+        eprintln!("Wrote output to: {}", output_path);
+    } else {
+        io::stdout().write_all(output.as_bytes())?;
+    }
+
+    Ok(())
+}
+
+fn load_object_info(path: &str) -> Result<ObjectInfo> {
+    let json = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read object_info file: {}", path))?;
+
+    let objects: Vec<rucomfyui::object_info::Object> =
+        serde_json::from_str(&json).with_context(|| "Failed to parse object_info.json")?;
+
+    Ok(objects.into_iter().map(|o| (o.name.clone(), o)).collect())
+}
+
+fn print_help() {
+    eprintln!(
+        r#"rucomfyui_workflow_converter - Convert ComfyUI API workflows to Rust or Lua code
+
+USAGE:
+    rucomfyui_workflow_converter <input.json> [OPTIONS]
+
+ARGUMENTS:
+    <input.json>    Path to the ComfyUI API workflow JSON file
+
+OPTIONS:
+    --rust           Output Rust code (default)
+    --lua            Output Lua code
+    --complete       Include boilerplate/wrapper code
+    --object-info    Path to object_info.json for typed Rust output
+                     (enables type-aware code generation)
+    --output, -o     Write to file instead of stdout
+    --help, -h       Show this help
+
+EXAMPLES:
+    # Convert to Rust using dynamic nodes
+    rucomfyui_workflow_converter workflow.json
+
+    # Convert to Rust with typed nodes using object_info
+    rucomfyui_workflow_converter workflow.json --object-info object_info.json --complete
+
+    # Convert to Lua with full boilerplate
+    rucomfyui_workflow_converter workflow.json --lua --complete
+
+    # Output to file
+    rucomfyui_workflow_converter workflow.json --complete -o workflow.rs
+"#
+    );
+}

--- a/crates/rucomfyui/src/workflow.rs
+++ b/crates/rucomfyui/src/workflow.rs
@@ -468,4 +468,9 @@ impl WorkflowMeta {
             title: title.into(),
         }
     }
+
+    /// Get the title.
+    pub fn title(&self) -> &str {
+        &self.title
+    }
 }

--- a/crates/rucomfyui_workflow_converter/Cargo.toml
+++ b/crates/rucomfyui_workflow_converter/Cargo.toml
@@ -21,6 +21,7 @@ syn = { version = "2", optional = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+full_moon = "2"
 prettyplease = "0.2"
 proc-macro2 = "1"
 quote = "1"

--- a/crates/rucomfyui_workflow_converter/Cargo.toml
+++ b/crates/rucomfyui_workflow_converter/Cargo.toml
@@ -21,4 +21,8 @@ syn = { version = "2", optional = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+prettyplease = "0.2"
+proc-macro2 = "1"
+quote = "1"
+syn = "2"
 tempfile = "3"

--- a/crates/rucomfyui_workflow_converter/Cargo.toml
+++ b/crates/rucomfyui_workflow_converter/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "rucomfyui_workflow_converter"
+version = "0.1.0"
+edition = "2021"
+description = "Convert ComfyUI API workflows to typed Rust or Lua code"
+
+[dependencies]
+anyhow = { workspace = true }
+convert_case = { workspace = true }
+prettyplease = "0.2"
+proc-macro2 = "1"
+quote = "1"
+rucomfyui = { path = "../rucomfyui" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+syn = "2"
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"
+serde_json = { workspace = true }

--- a/crates/rucomfyui_workflow_converter/Cargo.toml
+++ b/crates/rucomfyui_workflow_converter/Cargo.toml
@@ -6,11 +6,12 @@ description = "Convert ComfyUI API workflows to typed Rust or Lua code"
 
 [features]
 default = ["lua", "rust"]
-lua = []
+lua = ["dep:full_moon"]
 rust = ["dep:prettyplease", "dep:proc-macro2", "dep:quote", "dep:syn"]
 
 [dependencies]
 convert_case = { workspace = true }
+full_moon = { version = "2", optional = true }
 prettyplease = { version = "0.2", optional = true }
 proc-macro2 = { version = "1", optional = true }
 quote = { version = "1", optional = true }

--- a/crates/rucomfyui_workflow_converter/Cargo.toml
+++ b/crates/rucomfyui_workflow_converter/Cargo.toml
@@ -4,18 +4,21 @@ version = "0.1.0"
 edition = "2021"
 description = "Convert ComfyUI API workflows to typed Rust or Lua code"
 
+[features]
+default = ["lua", "rust"]
+lua = []
+rust = ["dep:prettyplease", "dep:proc-macro2", "dep:quote", "dep:syn"]
+
 [dependencies]
-anyhow = { workspace = true }
 convert_case = { workspace = true }
-prettyplease = "0.2"
-proc-macro2 = "1"
-quote = "1"
+prettyplease = { version = "0.2", optional = true }
+proc-macro2 = { version = "1", optional = true }
+quote = { version = "1", optional = true }
 rucomfyui = { path = "../rucomfyui" }
 serde = { workspace = true }
 serde_json = { workspace = true }
-syn = "2"
+syn = { version = "2", optional = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
-serde_json = { workspace = true }

--- a/crates/rucomfyui_workflow_converter/src/lib.rs
+++ b/crates/rucomfyui_workflow_converter/src/lib.rs
@@ -32,7 +32,7 @@ mod rust_generator;
 mod workflow_analyzer;
 
 #[cfg(feature = "lua")]
-pub use lua_generator::convert_to_lua;
+pub use lua_generator::{convert_to_lua, convert_to_lua_ast};
 #[cfg(feature = "rust")]
 pub use rust_generator::convert_to_rust;
 pub use workflow_analyzer::{AnalyzedNode, AnalyzedWorkflow};

--- a/crates/rucomfyui_workflow_converter/src/lib.rs
+++ b/crates/rucomfyui_workflow_converter/src/lib.rs
@@ -34,7 +34,7 @@ mod workflow_analyzer;
 #[cfg(feature = "lua")]
 pub use lua_generator::{convert_to_lua, convert_to_lua_ast};
 #[cfg(feature = "rust")]
-pub use rust_generator::convert_to_rust;
+pub use rust_generator::{convert_to_rust, convert_to_rust_tokens};
 pub use workflow_analyzer::{AnalyzedNode, AnalyzedWorkflow};
 
 use thiserror::Error;

--- a/crates/rucomfyui_workflow_converter/src/lib.rs
+++ b/crates/rucomfyui_workflow_converter/src/lib.rs
@@ -9,10 +9,7 @@
 //! # Example
 //!
 //! ```ignore
-//! use rucomfyui_workflow_converter::{
-//!     convert_to_rust_with_object_info, convert_to_lua_with_object_info,
-//!     RustGeneratorConfig, LuaGeneratorConfig,
-//! };
+//! use rucomfyui_workflow_converter::{convert_to_rust, convert_to_lua};
 //!
 //! let workflow_json = r#"{
 //!     "1": {
@@ -24,17 +21,8 @@
 //! // Load ObjectInfo from ComfyUI or a saved file
 //! let object_info = load_object_info();
 //!
-//! let rust_code = convert_to_rust_with_object_info(
-//!     workflow_json,
-//!     &object_info,
-//!     &RustGeneratorConfig::snippet(),
-//! ).unwrap();
-//!
-//! let lua_code = convert_to_lua_with_object_info(
-//!     workflow_json,
-//!     &object_info,
-//!     &LuaGeneratorConfig::snippet(),
-//! ).unwrap();
+//! let rust_code = convert_to_rust(workflow_json, &object_info).unwrap();
+//! let lua_code = convert_to_lua(workflow_json, &object_info).unwrap();
 //! ```
 
 #[cfg(feature = "lua")]
@@ -44,12 +32,9 @@ mod rust_generator;
 mod workflow_analyzer;
 
 #[cfg(feature = "lua")]
-pub use lua_generator::{convert_to_lua_with_object_info, LuaGeneratorConfig};
+pub use lua_generator::convert_to_lua;
 #[cfg(feature = "rust")]
-pub use rust_generator::{
-    convert_to_rust, convert_to_rust_with_config, convert_to_rust_with_object_info,
-    RustGeneratorConfig,
-};
+pub use rust_generator::convert_to_rust;
 pub use workflow_analyzer::{AnalyzedNode, AnalyzedWorkflow};
 
 use thiserror::Error;

--- a/crates/rucomfyui_workflow_converter/src/lib.rs
+++ b/crates/rucomfyui_workflow_converter/src/lib.rs
@@ -4,10 +4,15 @@
 //! - Typed Rust code compatible with `rucomfyui`'s `typed_nodes` feature (requires `rust` feature)
 //! - Lua code compatible with `rucomfyui_mlua` (requires `lua` feature)
 //!
+//! Both generators require an `ObjectInfo` to provide type information about nodes.
+//!
 //! # Example
 //!
-//! ```no_run
-//! use rucomfyui_workflow_converter::{convert_to_rust, convert_to_lua};
+//! ```ignore
+//! use rucomfyui_workflow_converter::{
+//!     convert_to_rust_with_object_info, convert_to_lua_with_object_info,
+//!     RustGeneratorConfig, LuaGeneratorConfig,
+//! };
 //!
 //! let workflow_json = r#"{
 //!     "1": {
@@ -16,8 +21,20 @@
 //!     }
 //! }"#;
 //!
-//! let rust_code = convert_to_rust(workflow_json).unwrap();
-//! let lua_code = convert_to_lua(workflow_json).unwrap();
+//! // Load ObjectInfo from ComfyUI or a saved file
+//! let object_info = load_object_info();
+//!
+//! let rust_code = convert_to_rust_with_object_info(
+//!     workflow_json,
+//!     &object_info,
+//!     &RustGeneratorConfig::snippet(),
+//! ).unwrap();
+//!
+//! let lua_code = convert_to_lua_with_object_info(
+//!     workflow_json,
+//!     &object_info,
+//!     &LuaGeneratorConfig::snippet(),
+//! ).unwrap();
 //! ```
 
 #[cfg(feature = "lua")]
@@ -27,7 +44,7 @@ mod rust_generator;
 mod workflow_analyzer;
 
 #[cfg(feature = "lua")]
-pub use lua_generator::{convert_to_lua, convert_to_lua_with_config, LuaGeneratorConfig};
+pub use lua_generator::{convert_to_lua_with_object_info, LuaGeneratorConfig};
 #[cfg(feature = "rust")]
 pub use rust_generator::{
     convert_to_rust, convert_to_rust_with_config, convert_to_rust_with_object_info,

--- a/crates/rucomfyui_workflow_converter/src/lib.rs
+++ b/crates/rucomfyui_workflow_converter/src/lib.rs
@@ -1,0 +1,52 @@
+//! Convert ComfyUI API workflows to typed Rust or Lua code.
+//!
+//! This library takes a ComfyUI API workflow JSON and converts it to either:
+//! - Typed Rust code compatible with `rucomfyui`'s `typed_nodes` feature
+//! - Lua code compatible with `rucomfyui_mlua`
+//!
+//! # Example
+//!
+//! ```no_run
+//! use rucomfyui_workflow_converter::{convert_to_rust, convert_to_lua};
+//!
+//! let workflow_json = r#"{
+//!     "1": {
+//!         "inputs": { "ckpt_name": "model.safetensors" },
+//!         "class_type": "CheckpointLoaderSimple"
+//!     }
+//! }"#;
+//!
+//! let rust_code = convert_to_rust(workflow_json).unwrap();
+//! let lua_code = convert_to_lua(workflow_json).unwrap();
+//! ```
+
+mod lua_generator;
+mod rust_generator;
+mod workflow_analyzer;
+
+pub use lua_generator::{convert_to_lua, convert_to_lua_with_config, LuaGeneratorConfig};
+pub use rust_generator::{
+    convert_to_rust, convert_to_rust_with_config, convert_to_rust_with_object_info,
+    RustGeneratorConfig,
+};
+pub use workflow_analyzer::{AnalyzedNode, AnalyzedWorkflow};
+
+use thiserror::Error;
+
+/// Errors that can occur during workflow conversion.
+#[derive(Error, Debug)]
+pub enum ConversionError {
+    #[error("Failed to parse workflow JSON: {0}")]
+    JsonParse(#[from] serde_json::Error),
+
+    #[error("Workflow contains a cycle")]
+    CyclicWorkflow,
+
+    #[error("Invalid node reference: {0}")]
+    InvalidNodeReference(String),
+
+    #[error("Node {0} not found in workflow")]
+    NodeNotFound(String),
+}
+
+pub type Result<T> = std::result::Result<T, ConversionError>;

--- a/crates/rucomfyui_workflow_converter/src/lib.rs
+++ b/crates/rucomfyui_workflow_converter/src/lib.rs
@@ -1,8 +1,8 @@
 //! Convert ComfyUI API workflows to typed Rust or Lua code.
 //!
 //! This library takes a ComfyUI API workflow JSON and converts it to either:
-//! - Typed Rust code compatible with `rucomfyui`'s `typed_nodes` feature
-//! - Lua code compatible with `rucomfyui_mlua`
+//! - Typed Rust code compatible with `rucomfyui`'s `typed_nodes` feature (requires `rust` feature)
+//! - Lua code compatible with `rucomfyui_mlua` (requires `lua` feature)
 //!
 //! # Example
 //!
@@ -20,11 +20,15 @@
 //! let lua_code = convert_to_lua(workflow_json).unwrap();
 //! ```
 
+#[cfg(feature = "lua")]
 mod lua_generator;
+#[cfg(feature = "rust")]
 mod rust_generator;
 mod workflow_analyzer;
 
+#[cfg(feature = "lua")]
 pub use lua_generator::{convert_to_lua, convert_to_lua_with_config, LuaGeneratorConfig};
+#[cfg(feature = "rust")]
 pub use rust_generator::{
     convert_to_rust, convert_to_rust_with_config, convert_to_rust_with_object_info,
     RustGeneratorConfig,

--- a/crates/rucomfyui_workflow_converter/src/lua_generator.rs
+++ b/crates/rucomfyui_workflow_converter/src/lua_generator.rs
@@ -288,7 +288,7 @@ fn table_args(fields: Vec<(String, Expression)>, indent: usize) -> FunctionArgs 
     FunctionArgs::TableConstructor(
         TableConstructor::new()
             .with_braces(ContainedSpan::new(
-                symbol("{"),
+                symbol_with_leading_space("{"),
                 symbol_with_leading_whitespace("}", &format!("\n{}", closing_indent)),
             ))
             .with_fields(punctuated_fields),
@@ -401,6 +401,10 @@ fn make_indent(level: usize) -> String {
 
 fn symbol(s: &str) -> TokenReference {
     TokenReference::symbol(s).expect("valid symbol")
+}
+
+fn symbol_with_leading_space(s: &str) -> TokenReference {
+    TokenReference::symbol(&format!(" {}", s)).expect("valid symbol")
 }
 
 fn symbol_with_surrounding_space(s: &str) -> TokenReference {

--- a/crates/rucomfyui_workflow_converter/src/lua_generator.rs
+++ b/crates/rucomfyui_workflow_converter/src/lua_generator.rs
@@ -211,4 +211,29 @@ mod tests {
         assert!(result.contains("clip_text_encode"));
         assert!(result.contains("k_sampler"));
     }
+
+    /// Test the complete example workflow from testdata/.
+    #[test]
+    fn test_example_workflow() {
+        let object_info = load_test_object_info();
+        let json = include_str!("../testdata/example_workflow.json");
+
+        let result = convert_to_lua(json, &object_info).unwrap();
+
+        // Verify all nodes are present
+        assert!(result.contains("local checkpoint_loader_simple = g:CheckpointLoaderSimple"));
+        assert!(result.contains("local clip_text_encode = g:CLIPTextEncode"));
+        assert!(result.contains("local clip_text_encode_1 = g:CLIPTextEncode"));
+        assert!(result.contains("local empty_latent_image = g:EmptyLatentImage"));
+        assert!(result.contains("local k_sampler = g:KSampler"));
+        assert!(result.contains("local vae_decode = g:VAEDecode"));
+        assert!(result.contains("local preview_image = g:PreviewImage"));
+
+        // Verify key references
+        assert!(result.contains("checkpoint_loader_simple.model"));
+        assert!(result.contains("checkpoint_loader_simple.clip"));
+        assert!(result.contains("checkpoint_loader_simple.vae"));
+        assert!(result.contains("positive = clip_text_encode,"));
+        assert!(result.contains("negative = clip_text_encode_1,"));
+    }
 }

--- a/crates/rucomfyui_workflow_converter/src/lua_generator.rs
+++ b/crates/rucomfyui_workflow_converter/src/lua_generator.rs
@@ -1,82 +1,380 @@
-//! Lua code generation from workflows.
+//! Lua code generation from workflows using full_moon AST.
 
 use crate::workflow_analyzer::{AnalyzedInput, AnalyzedNode, AnalyzedWorkflow};
 use crate::Result;
 use convert_case::{Case, Casing};
+use full_moon::ast::{
+    punctuated::{Pair, Punctuated},
+    span::ContainedSpan,
+    Block, Call, Expression, Field, FunctionArgs, FunctionCall, Index, LocalAssignment, Prefix,
+    Stmt, Suffix, TableConstructor, Var, VarExpression,
+};
+use full_moon::tokenizer::{Token, TokenReference, TokenType};
+use full_moon::ShortString;
 use rucomfyui::object_info::{Object, ObjectInfo};
 use std::collections::HashMap;
-use std::fmt::Write;
+
+// =============================================================================
+// Token creation helpers
+// =============================================================================
+
+fn ident(name: &str) -> TokenReference {
+    TokenReference::new(
+        vec![],
+        Token::new(TokenType::Identifier {
+            identifier: ShortString::new(name),
+        }),
+        vec![],
+    )
+}
+
+fn ident_with_leading_space(name: &str) -> TokenReference {
+    TokenReference::new(
+        vec![Token::new(TokenType::Whitespace {
+            characters: ShortString::new(" "),
+        })],
+        Token::new(TokenType::Identifier {
+            identifier: ShortString::new(name),
+        }),
+        vec![],
+    )
+}
+
+fn ident_with_leading_newline_indent(name: &str) -> TokenReference {
+    TokenReference::new(
+        vec![Token::new(TokenType::Whitespace {
+            characters: ShortString::new("\n    "),
+        })],
+        Token::new(TokenType::Identifier {
+            identifier: ShortString::new(name),
+        }),
+        vec![],
+    )
+}
+
+fn symbol(s: &str) -> TokenReference {
+    TokenReference::symbol(s).expect("valid symbol")
+}
+
+fn symbol_with_leading_space(s: &str) -> TokenReference {
+    TokenReference::symbol(&format!(" {}", s)).expect("valid symbol")
+}
+
+fn symbol_with_trailing_space(s: &str) -> TokenReference {
+    TokenReference::symbol(&format!("{} ", s)).expect("valid symbol")
+}
+
+fn number_token(value: &str) -> TokenReference {
+    TokenReference::new(
+        vec![],
+        Token::new(TokenType::Number {
+            text: ShortString::new(value),
+        }),
+        vec![],
+    )
+}
+
+fn string_token(value: &str) -> TokenReference {
+    TokenReference::new(
+        vec![],
+        Token::new(TokenType::StringLiteral {
+            literal: ShortString::new(value),
+            multi_line_depth: 0,
+            quote_type: full_moon::tokenizer::StringLiteralQuoteType::Double,
+        }),
+        vec![],
+    )
+}
+
+fn comment_token(text: &str) -> Token {
+    Token::new(TokenType::SingleLineComment {
+        comment: ShortString::new(text),
+    })
+}
+
+fn local_token() -> TokenReference {
+    TokenReference::new(
+        vec![],
+        Token::new(TokenType::Symbol {
+            symbol: full_moon::tokenizer::Symbol::Local,
+        }),
+        vec![],
+    )
+}
+
+fn local_token_with_leading_newline() -> TokenReference {
+    TokenReference::new(
+        vec![Token::new(TokenType::Whitespace {
+            characters: ShortString::new("\n"),
+        })],
+        Token::new(TokenType::Symbol {
+            symbol: full_moon::tokenizer::Symbol::Local,
+        }),
+        vec![],
+    )
+}
+
+fn local_token_with_comment(comment: &str) -> TokenReference {
+    TokenReference::new(
+        vec![
+            Token::new(TokenType::Whitespace {
+                characters: ShortString::new("\n"),
+            }),
+            comment_token(&format!(" {}", comment)),
+            Token::new(TokenType::Whitespace {
+                characters: ShortString::new("\n"),
+            }),
+        ],
+        Token::new(TokenType::Symbol {
+            symbol: full_moon::tokenizer::Symbol::Local,
+        }),
+        vec![],
+    )
+}
+
+fn local_token_first_with_comment(comment: &str) -> TokenReference {
+    TokenReference::new(
+        vec![
+            comment_token(&format!(" {}", comment)),
+            Token::new(TokenType::Whitespace {
+                characters: ShortString::new("\n"),
+            }),
+        ],
+        Token::new(TokenType::Symbol {
+            symbol: full_moon::tokenizer::Symbol::Local,
+        }),
+        vec![],
+    )
+}
+
+// =============================================================================
+// Expression builders
+// =============================================================================
+
+fn string_expr(value: &str) -> Expression {
+    Expression::String(string_token(&escape_lua_string(value)))
+}
+
+fn number_expr(value: &str) -> Expression {
+    Expression::Number(number_token(value))
+}
+
+fn var_expr(name: &str) -> Expression {
+    Expression::Var(Var::Name(ident(name)))
+}
+
+fn field_access_expr(var_name: &str, field_name: &str) -> Expression {
+    Expression::Var(Var::Expression(Box::new(
+        VarExpression::new(Prefix::Name(ident(var_name))).with_suffixes(vec![Suffix::Index(
+            Index::Dot {
+                dot: symbol("."),
+                name: ident(field_name),
+            },
+        )]),
+    )))
+}
+
+fn index_access_expr(var_name: &str, index: u32) -> Expression {
+    Expression::Var(Var::Expression(Box::new(
+        VarExpression::new(Prefix::Name(ident(var_name))).with_suffixes(vec![Suffix::Index(
+            Index::Brackets {
+                brackets: ContainedSpan::new(symbol("["), symbol("]")),
+                expression: number_expr(&index.to_string()),
+            },
+        )]),
+    )))
+}
+
+fn bool_expr(value: bool) -> Expression {
+    let token = if value {
+        TokenReference::symbol("true").unwrap()
+    } else {
+        TokenReference::symbol("false").unwrap()
+    };
+    Expression::Symbol(token)
+}
+
+// =============================================================================
+// Statement builders
+// =============================================================================
+
+/// Build a local assignment: `local name = expr`
+fn local_assignment(local_tok: TokenReference, name: &str, expr: Expression) -> Stmt {
+    let mut names = Punctuated::new();
+    names.push(Pair::End(ident_with_leading_space(name)));
+
+    let mut exprs = Punctuated::new();
+    exprs.push(Pair::End(expr));
+
+    Stmt::LocalAssignment(
+        LocalAssignment::new(names)
+            .with_local_token(local_tok)
+            .with_equal_token(Some(symbol_with_leading_space("=")))
+            .with_expressions(exprs),
+    )
+}
+
+/// Build a method call: `prefix:method(args)` or `prefix:method { table }`
+fn method_call(prefix_name: &str, method_name: &str, args: FunctionArgs) -> FunctionCall {
+    FunctionCall::new(Prefix::Name(ident(prefix_name))).with_suffixes(vec![Suffix::Call(
+        Call::MethodCall(
+            full_moon::ast::MethodCall::new(ident(method_name), args).with_colon_token(symbol(":")),
+        ),
+    )])
+}
+
+/// Build parenthesized arguments: `(expr)`
+fn paren_args(expr: Expression) -> FunctionArgs {
+    let mut exprs = Punctuated::new();
+    exprs.push(Pair::End(expr));
+    FunctionArgs::Parentheses {
+        parentheses: ContainedSpan::new(symbol("("), symbol(")")),
+        arguments: exprs,
+    }
+}
+
+/// Build empty parenthesized arguments: `()`
+fn empty_paren_args() -> FunctionArgs {
+    FunctionArgs::Parentheses {
+        parentheses: ContainedSpan::new(symbol("("), symbol(")")),
+        arguments: Punctuated::new(),
+    }
+}
+
+/// Build table constructor arguments: `{ fields }`
+fn table_args(fields: Vec<(String, Expression)>) -> FunctionArgs {
+    let mut punctuated_fields: Punctuated<Field> = Punctuated::new();
+
+    for (name, expr) in fields.into_iter() {
+        let field = Field::NameKey {
+            key: ident_with_leading_newline_indent(&name),
+            equal: symbol_with_leading_space("="),
+            value: expr,
+        };
+        punctuated_fields.push(Pair::Punctuated(field, symbol(",")));
+    }
+
+    FunctionArgs::TableConstructor(
+        TableConstructor::new()
+            .with_braces(ContainedSpan::new(
+                symbol_with_trailing_space("{"),
+                symbol("\n}"),
+            ))
+            .with_fields(punctuated_fields),
+    )
+}
+
+// =============================================================================
+// Main conversion functions
+// =============================================================================
 
 /// Convert a workflow JSON to Lua code using ObjectInfo for type information.
 pub fn convert_to_lua(json: &str, object_info: &ObjectInfo) -> Result<String> {
-    let analyzed = AnalyzedWorkflow::from_json(json)?;
-    generate_lua_code(&analyzed, object_info)
+    let ast = convert_to_lua_ast(json, object_info)?;
+    Ok(ast.to_string())
 }
 
-fn generate_lua_code(analyzed: &AnalyzedWorkflow, object_info: &ObjectInfo) -> Result<String> {
-    let mut output = String::new();
+/// Convert a workflow JSON to a full_moon AST.
+pub fn convert_to_lua_ast(json: &str, object_info: &ObjectInfo) -> Result<full_moon::ast::Ast> {
+    let analyzed = AnalyzedWorkflow::from_json(json)?;
+    generate_lua_ast(&analyzed, object_info)
+}
+
+fn generate_lua_ast(
+    analyzed: &AnalyzedWorkflow,
+    object_info: &ObjectInfo,
+) -> Result<full_moon::ast::Ast> {
+    let mut stmts: Vec<(Stmt, Option<TokenReference>)> = Vec::new();
 
     // Track generated variables with their ObjectInfo
     let mut generated_vars: HashMap<String, (&AnalyzedNode, Option<&Object>)> = HashMap::new();
 
     // Generate code for each node
-    for node in &analyzed.nodes {
+    for (i, node) in analyzed.nodes.iter().enumerate() {
         let obj = object_info.get(&node.class_type);
 
-        // Add comment
-        if let Some(display_name) = &node.display_name {
-            writeln!(output, "-- {} ({})", display_name, node.class_type).unwrap();
-        }
+        // Build the function call expression
+        let func_call_expr = build_node_call(node, &generated_vars)?;
 
-        // Start the node creation
-        write!(output, "local {} = g:{}", node.var_name, node.class_type).unwrap();
-
-        // Check if we can use positional or need named arguments
-        let use_table = node.inputs.len() > 1
-            || node
-                .inputs
-                .iter()
-                .any(|(_, v)| matches!(v, AnalyzedInput::NodeRef { .. }));
-
-        if node.inputs.is_empty() {
-            writeln!(output, "()").unwrap();
-        } else if !use_table && node.inputs.len() == 1 {
-            // Single simple argument - can use positional
-            let (_, input) = node.inputs.iter().next().unwrap();
-            let value = format_lua_value(input, &generated_vars)?;
-            writeln!(output, "({})", value).unwrap();
-        } else {
-            // Multiple arguments or node references - use table syntax
-            writeln!(output, " {{").unwrap();
-            for (name, input) in &node.inputs {
-                let value = format_lua_value(input, &generated_vars)?;
-                writeln!(output, "    {} = {},", name, value).unwrap();
+        // Determine the local token (with or without comment, first or not)
+        let local_tok = match (&node.display_name, i == 0) {
+            (Some(display_name), true) => {
+                let comment = format!("{} ({})", display_name, node.class_type);
+                local_token_first_with_comment(&comment)
             }
-            writeln!(output, "}}").unwrap();
-        }
+            (Some(display_name), false) => {
+                let comment = format!("{} ({})", display_name, node.class_type);
+                local_token_with_comment(&comment)
+            }
+            (None, true) => local_token(),
+            (None, false) => local_token_with_leading_newline(),
+        };
 
+        let stmt = local_assignment(
+            local_tok,
+            &node.var_name,
+            Expression::FunctionCall(func_call_expr),
+        );
+
+        stmts.push((stmt, None));
         generated_vars.insert(node.var_name.clone(), (node, obj));
     }
 
-    Ok(output)
+    let block = Block::new().with_stmts(stmts);
+    let empty_ast = full_moon::parse("").expect("empty string is valid lua");
+    Ok(empty_ast.with_nodes(block))
 }
 
-fn format_lua_value(
+fn build_node_call(
+    node: &AnalyzedNode,
+    generated_vars: &HashMap<String, (&AnalyzedNode, Option<&Object>)>,
+) -> Result<FunctionCall> {
+    // Check if we can use positional or need named arguments
+    let use_table = node.inputs.len() > 1
+        || node
+            .inputs
+            .iter()
+            .any(|(_, v)| matches!(v, AnalyzedInput::NodeRef { .. }));
+
+    let args = if node.inputs.is_empty() {
+        empty_paren_args()
+    } else if !use_table && node.inputs.len() == 1 {
+        // Single simple argument - can use positional
+        let (_, input) = node.inputs.iter().next().unwrap();
+        let expr = build_input_expr(input, generated_vars)?;
+        paren_args(expr)
+    } else {
+        // Multiple arguments or node references - use table syntax
+        let fields: Vec<(String, Expression)> = node
+            .inputs
+            .iter()
+            .map(|(name, input)| {
+                let expr = build_input_expr(input, generated_vars)?;
+                Ok((name.clone(), expr))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        table_args(fields)
+    };
+
+    Ok(method_call("g", &node.class_type, args))
+}
+
+fn build_input_expr(
     input: &AnalyzedInput,
     generated_vars: &HashMap<String, (&AnalyzedNode, Option<&Object>)>,
-) -> Result<String> {
+) -> Result<Expression> {
     match input {
-        AnalyzedInput::String(s) => Ok(format!("\"{}\"", escape_lua_string(s))),
-        AnalyzedInput::Integer(i) => Ok(i.to_string()),
+        AnalyzedInput::String(s) => Ok(string_expr(s)),
+        AnalyzedInput::Integer(i) => Ok(number_expr(&i.to_string())),
         AnalyzedInput::Float(f) => {
             let s = f.to_string();
             if s.contains('.') || s.contains('e') || s.contains('E') {
-                Ok(s)
+                Ok(number_expr(&s))
             } else {
-                Ok(format!("{}.0", s))
+                Ok(number_expr(&format!("{}.0", s)))
             }
         }
-        AnalyzedInput::Boolean(b) => Ok(b.to_string()),
+        AnalyzedInput::Boolean(b) => Ok(bool_expr(*b)),
         AnalyzedInput::NodeRef { var_name, slot } => {
             // Look up the referenced node to get its output field name from ObjectInfo
             if let Some((_ref_node, Some(ref_obj))) = generated_vars.get(var_name) {
@@ -85,17 +383,17 @@ fn format_lua_value(
                     // Multi-output node - use field name
                     if let Some(output) = outputs.get(*slot as usize) {
                         let field_name = output.name.to_case(Case::Snake);
-                        return Ok(format!("{}.{}", var_name, field_name));
+                        return Ok(field_access_expr(var_name, &field_name));
                     }
                 }
             }
             // Single-output or unknown - use variable directly
             if *slot == 0 {
-                Ok(var_name.clone())
+                Ok(var_expr(var_name))
             } else {
                 // For unknown multi-output nodes, use array-style access
                 // Lua is 1-indexed, so we add 1
-                Ok(format!("{}[{}]", var_name, slot + 1))
+                Ok(index_access_expr(var_name, *slot + 1))
             }
         }
     }
@@ -112,6 +410,7 @@ fn escape_lua_string(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use full_moon::node::Node;
 
     fn load_test_object_info() -> ObjectInfo {
         let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -134,20 +433,22 @@ mod tests {
     /// Dedent a string by removing common leading whitespace from all lines.
     fn dedent(code: &str) -> String {
         let lines: Vec<&str> = code.lines().collect();
-        let non_empty_lines: Vec<&str> = lines.iter().filter(|l| !l.trim().is_empty()).copied().collect();
+        let non_empty_lines: Vec<&str> = lines
+            .iter()
+            .filter(|l| !l.trim().is_empty())
+            .copied()
+            .collect();
 
         if non_empty_lines.is_empty() {
             return String::new();
         }
 
-        // Find minimum indentation
         let min_indent = non_empty_lines
             .iter()
             .map(|line| line.len() - line.trim_start().len())
             .min()
             .unwrap_or(0);
 
-        // Remove that indentation from all lines
         lines
             .iter()
             .map(|line| {
@@ -169,17 +470,14 @@ mod tests {
         full_moon::parse(&dedented).expect("Failed to parse Lua code")
     }
 
-    /// Assert that two Lua code strings parse to semantically similar ASTs.
-    fn assert_lua_eq(actual: &str, expected: &str) {
-        use full_moon::node::Node;
-
-        let actual_ast = parse_lua(actual);
+    /// Assert that a generated AST is semantically similar to expected code.
+    fn assert_ast_eq(actual: &full_moon::ast::Ast, expected: &str) {
         let expected_ast = parse_lua(expected);
 
         assert!(
-            actual_ast.nodes().similar(expected_ast.nodes()),
+            actual.nodes().similar(expected_ast.nodes()),
             "\n\nActual:\n{}\n\nExpected:\n{}",
-            actual_ast,
+            actual,
             expected_ast
         );
     }
@@ -195,15 +493,15 @@ mod tests {
             }
         }"#;
 
-        let result = convert_to_lua(json, &object_info).unwrap();
+        // Test AST generation directly
+        let ast = convert_to_lua_ast(json, &object_info).unwrap();
 
-        // Comment is generated from _meta.title
         let expected = r#"
             -- Load Checkpoint (CheckpointLoaderSimple)
             local checkpoint_loader_simple = g:CheckpointLoaderSimple("sd_xl_base_1.0.safetensors")
         "#;
 
-        assert_lua_eq(&result, expected);
+        assert_ast_eq(&ast, expected);
     }
 
     #[test]
@@ -223,9 +521,8 @@ mod tests {
             }
         }"#;
 
-        let result = convert_to_lua(json, &object_info).unwrap();
+        let ast = convert_to_lua_ast(json, &object_info).unwrap();
 
-        // No comments since no _meta.title; fields are alphabetically ordered
         let expected = r#"
             local checkpoint_loader_simple = g:CheckpointLoaderSimple("model.safetensors")
             local clip_text_encode = g:CLIPTextEncode {
@@ -234,7 +531,7 @@ mod tests {
             }
         "#;
 
-        assert_lua_eq(&result, expected);
+        assert_ast_eq(&ast, expected);
     }
 
     #[test]
@@ -251,7 +548,7 @@ mod tests {
             }
         }"#;
 
-        let result = convert_to_lua(json, &object_info).unwrap();
+        let ast = convert_to_lua_ast(json, &object_info).unwrap();
 
         let expected = r#"
             local checkpoint_loader_simple = g:CheckpointLoaderSimple("model.safetensors")
@@ -261,7 +558,7 @@ mod tests {
             }
         "#;
 
-        assert_lua_eq(&result, expected);
+        assert_ast_eq(&ast, expected);
     }
 
     #[test]
@@ -278,9 +575,8 @@ mod tests {
             }
         }"#;
 
-        let result = convert_to_lua(json, &object_info).unwrap();
+        let ast = convert_to_lua_ast(json, &object_info).unwrap();
 
-        // Fields are alphabetically ordered; floats have .0 suffix
         let expected = r#"
             local empty_latent_image = g:EmptyLatentImage {
                 batch_size = 1.0,
@@ -289,7 +585,7 @@ mod tests {
             }
         "#;
 
-        assert_lua_eq(&result, expected);
+        assert_ast_eq(&ast, expected);
     }
 
     #[test]
@@ -310,7 +606,7 @@ mod tests {
             }
         }"#;
 
-        let result = convert_to_lua(json, &object_info).unwrap();
+        let ast = convert_to_lua_ast(json, &object_info).unwrap();
 
         let expected = r#"
             local checkpoint_loader_simple = g:CheckpointLoaderSimple("model.safetensors")
@@ -324,18 +620,16 @@ mod tests {
             }
         "#;
 
-        assert_lua_eq(&result, expected);
+        assert_ast_eq(&ast, expected);
     }
 
-    /// Test the complete example workflow from testdata/.
     #[test]
     fn test_example_workflow() {
         let object_info = load_test_object_info();
         let json = include_str!("../testdata/example_workflow.json");
 
-        let result = convert_to_lua(json, &object_info).unwrap();
+        let ast = convert_to_lua_ast(json, &object_info).unwrap();
 
-        // Comments from _meta.title; node order by topological sort; fields alphabetically ordered
         let expected = r#"
             -- Load Checkpoint (CheckpointLoaderSimple)
             local checkpoint_loader_simple = g:CheckpointLoaderSimple("model.safetensors")
@@ -379,6 +673,22 @@ mod tests {
             }
         "#;
 
-        assert_lua_eq(&result, expected);
+        assert_ast_eq(&ast, expected);
+    }
+
+    #[test]
+    fn test_string_to_ast_roundtrip() {
+        // Verify that convert_to_lua produces valid parseable Lua
+        let object_info = load_test_object_info();
+        let json = r#"{
+            "1": {
+                "inputs": { "ckpt_name": "model.safetensors" },
+                "class_type": "CheckpointLoaderSimple"
+            }
+        }"#;
+
+        let result = convert_to_lua(json, &object_info).unwrap();
+        // This should not panic - the output should be valid Lua
+        let _parsed = full_moon::parse(&result).expect("Generated Lua should be valid");
     }
 }

--- a/crates/rucomfyui_workflow_converter/src/lua_generator.rs
+++ b/crates/rucomfyui_workflow_converter/src/lua_generator.rs
@@ -1,0 +1,314 @@
+//! Lua code generation from workflows.
+
+use crate::workflow_analyzer::{AnalyzedInput, AnalyzedWorkflow};
+use crate::Result;
+use std::collections::HashMap;
+use std::fmt::Write;
+
+/// Configuration for Lua code generation.
+#[derive(Debug, Clone, Default)]
+pub struct LuaGeneratorConfig {
+    /// Whether to include the boilerplate code (get_object_info, graph creation).
+    pub include_boilerplate: bool,
+    /// Whether to include the execution code (client:easy_queue).
+    pub include_execution: bool,
+}
+
+impl LuaGeneratorConfig {
+    /// Create a config that generates just the workflow building code.
+    pub fn snippet() -> Self {
+        Self {
+            include_boilerplate: false,
+            include_execution: false,
+        }
+    }
+
+    /// Create a config that generates a complete executable script.
+    pub fn complete() -> Self {
+        Self {
+            include_boilerplate: true,
+            include_execution: true,
+        }
+    }
+}
+
+/// Mapping of node class types to their output field names for Lua.
+fn get_node_output_fields() -> HashMap<&'static str, Vec<&'static str>> {
+    let mut map = HashMap::new();
+
+    // Loaders with multiple outputs
+    map.insert("CheckpointLoaderSimple", vec!["model", "clip", "vae"]);
+    map.insert("CheckpointLoader", vec!["model", "clip", "vae"]);
+    map.insert(
+        "unCLIPCheckpointLoader",
+        vec!["model", "clip", "vae", "clip_vision"],
+    );
+    map.insert("LoraLoader", vec!["model", "clip"]);
+    map.insert(
+        "ImageOnlyCheckpointLoader",
+        vec!["model", "clip_vision", "vae"],
+    );
+    map.insert("DualCLIPLoader", vec!["clip"]);
+    map.insert("TripleCLIPLoader", vec!["clip"]);
+    map.insert("QuadrupleCLIPLoader", vec!["clip"]);
+
+    // Split nodes
+    map.insert("SplitImageWithAlpha", vec!["image", "mask"]);
+    map.insert("LoadImage", vec!["image", "mask"]);
+
+    // Sampling outputs
+    map.insert("SamplerCustom", vec!["output", "denoised_output"]);
+    map.insert("SamplerCustomAdvanced", vec!["output", "denoised_output"]);
+
+    map
+}
+
+/// Convert a workflow JSON to Lua code.
+pub fn convert_to_lua(json: &str) -> Result<String> {
+    convert_to_lua_with_config(json, &LuaGeneratorConfig::snippet())
+}
+
+/// Convert a workflow JSON to Lua code with configuration.
+pub fn convert_to_lua_with_config(json: &str, config: &LuaGeneratorConfig) -> Result<String> {
+    let analyzed = AnalyzedWorkflow::from_json(json)?;
+    generate_lua_code(&analyzed, config)
+}
+
+fn generate_lua_code(analyzed: &AnalyzedWorkflow, config: &LuaGeneratorConfig) -> Result<String> {
+    let mut output = String::new();
+    let node_outputs = get_node_output_fields();
+
+    if config.include_boilerplate {
+        writeln!(output, "-- Generated workflow from ComfyUI API workflow").unwrap();
+        writeln!(output, "-- Requires: comfy module and client to be set up").unwrap();
+        writeln!(output).unwrap();
+        writeln!(output, "-- Get object info and create graph").unwrap();
+        writeln!(output, "local object_info = client:get_object_info()").unwrap();
+        writeln!(output, "local g = comfy.graph(object_info)").unwrap();
+        writeln!(output).unwrap();
+        writeln!(output, "-- Build the workflow").unwrap();
+    }
+
+    // Track generated variables
+    let mut generated_vars: HashMap<String, String> = HashMap::new();
+
+    // Generate code for each node
+    for node in &analyzed.nodes {
+        // Add comment
+        if let Some(display_name) = &node.display_name {
+            writeln!(output, "-- {} ({})", display_name, node.class_type).unwrap();
+        }
+
+        // Start the node creation
+        write!(output, "local {} = g:{}", node.var_name, node.class_type).unwrap();
+
+        // Check if we can use positional or need named arguments
+        let use_table = node.inputs.len() > 1
+            || node
+                .inputs
+                .iter()
+                .any(|(_, v)| matches!(v, AnalyzedInput::NodeRef { .. }));
+
+        if node.inputs.is_empty() {
+            writeln!(output, "()").unwrap();
+        } else if !use_table && node.inputs.len() == 1 {
+            // Single simple argument - can use positional
+            let (_, input) = node.inputs.iter().next().unwrap();
+            let value = format_lua_value(input, &node_outputs, &generated_vars)?;
+            writeln!(output, "({})", value).unwrap();
+        } else {
+            // Multiple arguments or node references - use table syntax
+            writeln!(output, " {{").unwrap();
+            for (name, input) in &node.inputs {
+                let value = format_lua_value(input, &node_outputs, &generated_vars)?;
+                writeln!(output, "    {} = {},", name, value).unwrap();
+            }
+            writeln!(output, "}}").unwrap();
+        }
+
+        generated_vars.insert(node.var_name.clone(), node.class_type.clone());
+    }
+
+    if config.include_execution {
+        writeln!(output).unwrap();
+        writeln!(output, "-- Queue the workflow and wait for results").unwrap();
+        writeln!(output, "local result = client:easy_queue(g)").unwrap();
+
+        // Find likely output nodes
+        let output_nodes: Vec<_> = analyzed
+            .nodes
+            .iter()
+            .filter(|n| {
+                matches!(
+                    n.class_type.as_str(),
+                    "PreviewImage" | "SaveImage" | "SaveVideo" | "PreviewAudio" | "SaveAudio"
+                )
+            })
+            .collect();
+
+        if !output_nodes.is_empty() {
+            writeln!(output).unwrap();
+            writeln!(output, "-- Return results from output nodes").unwrap();
+            if output_nodes.len() == 1 {
+                writeln!(output, "return result[{}]", output_nodes[0].var_name).unwrap();
+            } else {
+                writeln!(output, "return {{").unwrap();
+                for node in &output_nodes {
+                    writeln!(output, "    {} = result[{}],", node.var_name, node.var_name).unwrap();
+                }
+                writeln!(output, "}}").unwrap();
+            }
+        }
+    }
+
+    Ok(output)
+}
+
+fn format_lua_value(
+    input: &AnalyzedInput,
+    node_outputs: &HashMap<&str, Vec<&str>>,
+    generated_vars: &HashMap<String, String>,
+) -> Result<String> {
+    match input {
+        AnalyzedInput::String(s) => Ok(format!("\"{}\"", escape_lua_string(s))),
+        AnalyzedInput::Integer(i) => Ok(i.to_string()),
+        AnalyzedInput::Float(f) => {
+            let s = f.to_string();
+            if s.contains('.') || s.contains('e') || s.contains('E') {
+                Ok(s)
+            } else {
+                Ok(format!("{}.0", s))
+            }
+        }
+        AnalyzedInput::Boolean(b) => Ok(b.to_string()),
+        AnalyzedInput::NodeRef { var_name, slot } => {
+            // Look up the referenced node to get its output field name
+            if let Some(class_type) = generated_vars.get(var_name) {
+                if let Some(fields) = node_outputs.get(class_type.as_str()) {
+                    if let Some(field_name) = fields.get(*slot as usize) {
+                        return Ok(format!("{}.{}", var_name, field_name));
+                    }
+                }
+            }
+            // For single-output nodes or unknown slots, just reference the variable
+            if *slot == 0 {
+                Ok(var_name.clone())
+            } else {
+                // For unknown multi-output nodes, use array-style access
+                // Lua is 1-indexed, so we add 1
+                Ok(format!("{}[{}]", var_name, slot + 1))
+            }
+        }
+    }
+}
+
+fn escape_lua_string(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_convert_simple_workflow() {
+        let json = r#"{
+            "1": {
+                "inputs": { "ckpt_name": "sd_xl_base_1.0.safetensors" },
+                "class_type": "CheckpointLoaderSimple",
+                "_meta": { "title": "Load Checkpoint" }
+            }
+        }"#;
+
+        let result = convert_to_lua(json).unwrap();
+        assert!(result.contains("g:CheckpointLoaderSimple"));
+        assert!(result.contains("sd_xl_base_1.0.safetensors"));
+    }
+
+    #[test]
+    fn test_convert_workflow_with_dependencies() {
+        let json = r#"{
+            "1": {
+                "inputs": { "ckpt_name": "model.safetensors" },
+                "class_type": "CheckpointLoaderSimple"
+            },
+            "2": {
+                "inputs": {
+                    "text": "a cat",
+                    "clip": ["1", 1]
+                },
+                "class_type": "CLIPTextEncode"
+            }
+        }"#;
+
+        let result = convert_to_lua(json).unwrap();
+        assert!(result.contains("checkpoint_loader_simple.clip"));
+    }
+
+    #[test]
+    fn test_convert_with_boilerplate() {
+        let json = r#"{
+            "1": {
+                "inputs": { "ckpt_name": "model.safetensors" },
+                "class_type": "CheckpointLoaderSimple"
+            },
+            "2": {
+                "inputs": { "images": ["1", 0] },
+                "class_type": "PreviewImage"
+            }
+        }"#;
+
+        let config = LuaGeneratorConfig::complete();
+        let result = convert_to_lua_with_config(json, &config).unwrap();
+        assert!(result.contains("client:get_object_info()"));
+        assert!(result.contains("comfy.graph(object_info)"));
+        assert!(result.contains("client:easy_queue(g)"));
+    }
+
+    #[test]
+    fn test_nested_workflow() {
+        let json = r#"{
+            "1": {
+                "inputs": { "ckpt_name": "model.safetensors" },
+                "class_type": "CheckpointLoaderSimple"
+            },
+            "2": {
+                "inputs": { "width": 1024, "height": 1024, "batch_size": 1 },
+                "class_type": "EmptyLatentImage"
+            },
+            "3": {
+                "inputs": {
+                    "model": ["1", 0],
+                    "seed": 0,
+                    "steps": 20,
+                    "cfg": 8.0,
+                    "sampler_name": "euler",
+                    "scheduler": "normal",
+                    "positive": ["4", 0],
+                    "negative": ["5", 0],
+                    "latent_image": ["2", 0],
+                    "denoise": 1.0
+                },
+                "class_type": "KSampler"
+            },
+            "4": {
+                "inputs": { "text": "a cat", "clip": ["1", 1] },
+                "class_type": "CLIPTextEncode"
+            },
+            "5": {
+                "inputs": { "text": "bad", "clip": ["1", 1] },
+                "class_type": "CLIPTextEncode"
+            }
+        }"#;
+
+        let result = convert_to_lua(json).unwrap();
+        assert!(result.contains("checkpoint_loader_simple.model"));
+        assert!(result.contains("checkpoint_loader_simple.clip"));
+        assert!(result.contains("clip_text_encode"));
+        assert!(result.contains("k_sampler"));
+    }
+}

--- a/crates/rucomfyui_workflow_converter/src/lua_generator.rs
+++ b/crates/rucomfyui_workflow_converter/src/lua_generator.rs
@@ -163,26 +163,24 @@ mod tests {
             .to_string()
     }
 
-    /// Parse Lua code and return a normalized string for comparison.
-    fn normalize_lua(code: &str) -> String {
-        // First dedent to remove raw string indentation
+    /// Parse Lua code and return the AST.
+    fn parse_lua(code: &str) -> full_moon::ast::Ast {
         let dedented = dedent(code);
-        let ast = full_moon::parse(&dedented).expect("Failed to parse Lua code");
-        // Use Display trait which preserves comments
-        ast.to_string().trim().to_string()
+        full_moon::parse(&dedented).expect("Failed to parse Lua code")
     }
 
-    /// Assert that two Lua code strings parse to equivalent ASTs.
+    /// Assert that two Lua code strings parse to semantically similar ASTs.
     fn assert_lua_eq(actual: &str, expected: &str) {
-        let actual_normalized = normalize_lua(actual);
-        let expected_normalized = normalize_lua(expected);
+        use full_moon::node::Node;
 
-        assert_eq!(
-            actual_normalized,
-            expected_normalized,
-            "\n\nActual (normalized):\n{}\n\nExpected (normalized):\n{}",
-            actual_normalized,
-            expected_normalized
+        let actual_ast = parse_lua(actual);
+        let expected_ast = parse_lua(expected);
+
+        assert!(
+            actual_ast.nodes().similar(expected_ast.nodes()),
+            "\n\nActual:\n{}\n\nExpected:\n{}",
+            actual_ast,
+            expected_ast
         );
     }
 

--- a/crates/rucomfyui_workflow_converter/src/rust_generator.rs
+++ b/crates/rucomfyui_workflow_converter/src/rust_generator.rs
@@ -1,0 +1,461 @@
+//! Rust code generation from workflows using ObjectInfo.
+
+use crate::workflow_analyzer::{AnalyzedInput, AnalyzedNode, AnalyzedWorkflow};
+use crate::Result;
+use convert_case::{Case, Casing};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use rucomfyui::object_info::{Object, ObjectInfo, ObjectType};
+use std::collections::HashMap;
+
+/// Configuration for Rust code generation.
+#[derive(Debug, Clone, Default)]
+pub struct RustGeneratorConfig {
+    /// Whether to generate a complete compilable file with imports and function wrapper.
+    /// If false, generates just the workflow construction code.
+    pub include_wrapper: bool,
+    /// The function name to use when generating a complete file.
+    pub function_name: String,
+}
+
+impl RustGeneratorConfig {
+    /// Create a config that generates just the workflow code snippet.
+    pub fn snippet() -> Self {
+        Self {
+            include_wrapper: false,
+            function_name: String::new(),
+        }
+    }
+
+    /// Create a config that generates a complete file with the given function name.
+    pub fn complete(function_name: impl Into<String>) -> Self {
+        Self {
+            include_wrapper: true,
+            function_name: function_name.into(),
+        }
+    }
+}
+
+/// Convert a workflow JSON to Rust code without ObjectInfo (uses dynamic nodes).
+pub fn convert_to_rust(json: &str) -> Result<String> {
+    convert_to_rust_with_config(json, &RustGeneratorConfig::snippet())
+}
+
+/// Convert a workflow JSON to Rust code with configuration but without ObjectInfo.
+pub fn convert_to_rust_with_config(json: &str, config: &RustGeneratorConfig) -> Result<String> {
+    let analyzed = AnalyzedWorkflow::from_json(json)?;
+    generate_rust_code_dynamic(&analyzed, config)
+}
+
+/// Convert a workflow JSON to Rust code using ObjectInfo for type information.
+pub fn convert_to_rust_with_object_info(
+    json: &str,
+    object_info: &ObjectInfo,
+    config: &RustGeneratorConfig,
+) -> Result<String> {
+    let analyzed = AnalyzedWorkflow::from_json(json)?;
+    generate_rust_code_typed(&analyzed, object_info, config)
+}
+
+/// Generate Rust code using dynamic nodes (without ObjectInfo).
+fn generate_rust_code_dynamic(
+    analyzed: &AnalyzedWorkflow,
+    config: &RustGeneratorConfig,
+) -> Result<String> {
+    let mut nodes_tokens = Vec::new();
+    let mut generated_vars: HashMap<String, &AnalyzedNode> = HashMap::new();
+
+    for node in &analyzed.nodes {
+        let var_ident = format_ident!("{}", &node.var_name);
+        let class_type = &node.class_type;
+
+        let comment = if let Some(display_name) = &node.display_name {
+            format!("// {} ({})", display_name, class_type)
+        } else {
+            format!("// {}", class_type)
+        };
+        let comment_tokens: TokenStream = comment.parse().unwrap();
+
+        let mut input_calls = Vec::new();
+        for (name, input) in &node.inputs {
+            let value = format_dynamic_input_value(input, &generated_vars);
+            let value_tokens: TokenStream = value.parse().unwrap();
+            input_calls.push(quote! {
+                .with_input(#name, #value_tokens)
+            });
+        }
+
+        nodes_tokens.push(quote! {
+            #comment_tokens
+            let #var_ident = g.add_dynamic(
+                rucomfyui::workflow::WorkflowNode::new(#class_type)
+                    #(#input_calls)*
+            );
+        });
+
+        generated_vars.insert(node.var_name.clone(), node);
+    }
+
+    let output_node = analyzed
+        .nodes
+        .iter()
+        .rev()
+        .find(|n| is_likely_output_node(&n.class_type));
+
+    let output_ident = output_node
+        .map(|n| format_ident!("{}", &n.var_name))
+        .unwrap_or_else(|| format_ident!("WorkflowNodeId"));
+
+    let output_expr = if output_node.is_some() {
+        quote! { #output_ident }
+    } else {
+        quote! { WorkflowNodeId(0) }
+    };
+
+    let tokens = if config.include_wrapper {
+        let func_name = format_ident!(
+            "{}",
+            if config.function_name.is_empty() {
+                "workflow"
+            } else {
+                &config.function_name
+            }
+        );
+
+        quote! {
+            //! Generated workflow code from ComfyUI API workflow.
+
+            use rucomfyui::{Workflow, WorkflowGraph, WorkflowNodeId};
+
+            /// Constructs the workflow.
+            pub fn #func_name() -> (Workflow, WorkflowNodeId) {
+                let g = WorkflowGraph::new();
+
+                #(#nodes_tokens)*
+
+                (g.into_workflow(), #output_expr)
+            }
+        }
+    } else {
+        quote! {
+            let g = WorkflowGraph::new();
+
+            #(#nodes_tokens)*
+        }
+    };
+
+    if config.include_wrapper {
+        format_tokens_as_file(tokens)
+    } else {
+        format_tokens_as_snippet(tokens)
+    }
+}
+
+/// Generate Rust code using typed nodes with ObjectInfo.
+fn generate_rust_code_typed(
+    analyzed: &AnalyzedWorkflow,
+    object_info: &ObjectInfo,
+    config: &RustGeneratorConfig,
+) -> Result<String> {
+    let mut nodes_tokens = Vec::new();
+    let mut generated_vars: HashMap<String, (&AnalyzedNode, Option<&Object>)> = HashMap::new();
+
+    for node in &analyzed.nodes {
+        let var_ident = format_ident!("{}", &node.var_name);
+        let obj = object_info.get(&node.class_type);
+
+        let comment = if let Some(display_name) = &node.display_name {
+            format!("// {} ({})", display_name, node.class_type)
+        } else {
+            format!("// {}", node.class_type)
+        };
+        let comment_tokens: TokenStream = comment.parse().unwrap();
+
+        if let Some(obj) = obj {
+            // Known node - use typed node construction
+            let struct_ident = format_ident!("{}", &node.class_type);
+
+            let mut field_assignments = Vec::new();
+            for (name, input) in &node.inputs {
+                let field_ident = format_ident!("{}", name.to_case(Case::Snake));
+
+                // Get expected type for this input
+                let expected_type = obj
+                    .all_inputs()
+                    .find(|(n, _, _)| *n == name)
+                    .and_then(|(_, input, _)| input.as_type().cloned());
+
+                let value =
+                    format_typed_input_value(input, expected_type.as_ref(), &generated_vars);
+                let value_tokens: TokenStream = value.parse().unwrap();
+
+                field_assignments.push(quote! {
+                    #field_ident: #value_tokens
+                });
+            }
+
+            nodes_tokens.push(quote! {
+                #comment_tokens
+                let #var_ident = g.add(#struct_ident {
+                    #(#field_assignments),*
+                });
+            });
+        } else {
+            // Unknown node - use dynamic construction
+            let class_type = &node.class_type;
+            let mut input_calls = Vec::new();
+            for (name, input) in &node.inputs {
+                let value = format_dynamic_input_value(
+                    input,
+                    &generated_vars
+                        .iter()
+                        .map(|(k, (n, _))| (k.clone(), *n))
+                        .collect(),
+                );
+                let value_tokens: TokenStream = value.parse().unwrap();
+                input_calls.push(quote! {
+                    .with_input(#name, #value_tokens)
+                });
+            }
+
+            nodes_tokens.push(quote! {
+                #comment_tokens
+                let #var_ident = g.add_dynamic(
+                    rucomfyui::workflow::WorkflowNode::new(#class_type)
+                        #(#input_calls)*
+                );
+            });
+        }
+
+        generated_vars.insert(node.var_name.clone(), (node, obj));
+    }
+
+    // Find output node using ObjectInfo
+    let output_node = analyzed.nodes.iter().rev().find(|n| {
+        object_info
+            .get(&n.class_type)
+            .map(|o| o.output_node)
+            .unwrap_or(false)
+    });
+
+    let output_ident = output_node
+        .map(|n| format_ident!("{}", &n.var_name))
+        .unwrap_or_else(|| format_ident!("WorkflowNodeId"));
+
+    let output_expr = if output_node.is_some() {
+        quote! { #output_ident }
+    } else {
+        quote! { WorkflowNodeId(0) }
+    };
+
+    let tokens = if config.include_wrapper {
+        let func_name = format_ident!(
+            "{}",
+            if config.function_name.is_empty() {
+                "workflow"
+            } else {
+                &config.function_name
+            }
+        );
+
+        quote! {
+            //! Generated workflow code from ComfyUI API workflow.
+
+            use rucomfyui::{Workflow, WorkflowGraph, WorkflowNodeId};
+            use rucomfyui::nodes::all::*;
+
+            /// Constructs the workflow.
+            pub fn #func_name() -> (Workflow, WorkflowNodeId) {
+                let g = WorkflowGraph::new();
+
+                #(#nodes_tokens)*
+
+                (g.into_workflow(), #output_expr)
+            }
+        }
+    } else {
+        quote! {
+            let g = WorkflowGraph::new();
+
+            #(#nodes_tokens)*
+        }
+    };
+
+    if config.include_wrapper {
+        format_tokens_as_file(tokens)
+    } else {
+        format_tokens_as_snippet(tokens)
+    }
+}
+
+fn format_tokens_as_file(tokens: TokenStream) -> Result<String> {
+    let syntax_tree = syn::parse2::<syn::File>(tokens.clone())
+        .map_err(|e| crate::ConversionError::InvalidNodeReference(format!("Parse error: {}", e)))?;
+    Ok(prettyplease::unparse(&syntax_tree))
+}
+
+fn format_tokens_as_snippet(tokens: TokenStream) -> Result<String> {
+    // For snippets, wrap in a function to parse, then extract just the body
+    let wrapped = quote! {
+        fn __wrapper() {
+            #tokens
+        }
+    };
+    let syntax_tree = syn::parse2::<syn::File>(wrapped)
+        .map_err(|e| crate::ConversionError::InvalidNodeReference(format!("Parse error: {}", e)))?;
+    let formatted = prettyplease::unparse(&syntax_tree);
+
+    // Extract just the function body (between the first { and the last })
+    if let Some(start) = formatted.find('{') {
+        if let Some(end) = formatted.rfind('}') {
+            let body = &formatted[start + 1..end];
+            // Remove leading and trailing whitespace from each line and dedent
+            return Ok(body
+                .lines()
+                .map(|line| {
+                    // Remove exactly 4 spaces of indentation if present
+                    if let Some(stripped) = line.strip_prefix("    ") {
+                        stripped
+                    } else {
+                        line.trim_start()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+                .trim()
+                .to_string());
+        }
+    }
+    Ok(formatted)
+}
+
+fn format_dynamic_input_value(
+    input: &AnalyzedInput,
+    _generated_vars: &HashMap<String, &AnalyzedNode>,
+) -> String {
+    match input {
+        AnalyzedInput::String(s) => format!("\"{}\"", escape_string(s)),
+        AnalyzedInput::Integer(i) => format!("{}i64", i),
+        AnalyzedInput::Float(f) => {
+            let s = f.to_string();
+            if s.contains('.') || s.contains('e') || s.contains('E') {
+                s
+            } else {
+                format!("{}.0", s)
+            }
+        }
+        AnalyzedInput::Boolean(b) => b.to_string(),
+        AnalyzedInput::NodeRef { var_name, slot } => {
+            format!("{}.to_input_with_slot({})", var_name, slot)
+        }
+    }
+}
+
+fn format_typed_input_value(
+    input: &AnalyzedInput,
+    expected_type: Option<&ObjectType>,
+    generated_vars: &HashMap<String, (&AnalyzedNode, Option<&Object>)>,
+) -> String {
+    match input {
+        AnalyzedInput::String(s) => format!("\"{}\"", escape_string(s)),
+        AnalyzedInput::Integer(i) => i.to_string(),
+        AnalyzedInput::Float(f) => {
+            // Check if expected type is Int - if so, output as integer
+            if let Some(ObjectType::Int) = expected_type {
+                if f.fract() == 0.0 && f.abs() < i64::MAX as f64 {
+                    return format!("{}", *f as i64);
+                }
+            }
+            // Otherwise output as float
+            let s = f.to_string();
+            if s.contains('.') || s.contains('e') || s.contains('E') {
+                s
+            } else {
+                format!("{}.0", s)
+            }
+        }
+        AnalyzedInput::Boolean(b) => b.to_string(),
+        AnalyzedInput::NodeRef { var_name, slot } => {
+            // Look up the referenced node to get output field name
+            if let Some((_ref_node, Some(ref_obj))) = generated_vars.get(var_name) {
+                let outputs: Vec<_> = ref_obj.processed_output().collect();
+                if outputs.len() > 1 {
+                    // Multi-output node - use field name
+                    if let Some(output) = outputs.get(*slot as usize) {
+                        let field_name = output.name.to_case(Case::Snake);
+                        return format!("{}.{}", var_name, field_name);
+                    }
+                }
+            }
+            // Single-output or unknown - use variable directly
+            if *slot == 0 {
+                var_name.clone()
+            } else {
+                format!("{}.{}", var_name, slot)
+            }
+        }
+    }
+}
+
+fn escape_string(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t")
+}
+
+/// Check if a node is likely an output node (used when ObjectInfo is not available).
+fn is_likely_output_node(class_type: &str) -> bool {
+    matches!(
+        class_type,
+        "PreviewImage"
+            | "SaveImage"
+            | "PreviewAudio"
+            | "SaveAudio"
+            | "SaveAudioMP3"
+            | "SaveAudioOpus"
+            | "SaveVideo"
+            | "SaveAnimatedPNG"
+            | "SaveAnimatedWEBP"
+            | "SaveWEBM"
+            | "SaveGLB"
+            | "SaveSVGNode"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_convert_simple_workflow() {
+        let json = r#"{
+            "1": {
+                "inputs": { "ckpt_name": "sd_xl_base_1.0.safetensors" },
+                "class_type": "CheckpointLoaderSimple",
+                "_meta": { "title": "Load Checkpoint" }
+            }
+        }"#;
+
+        let result = convert_to_rust(json).unwrap();
+        assert!(result.contains("let g = WorkflowGraph::new()"));
+        assert!(result.contains("CheckpointLoaderSimple"));
+        assert!(result.contains("ckpt_name"));
+    }
+
+    #[test]
+    fn test_convert_with_wrapper() {
+        let json = r#"{
+            "1": {
+                "inputs": { "ckpt_name": "model.safetensors" },
+                "class_type": "CheckpointLoaderSimple"
+            }
+        }"#;
+
+        let config = RustGeneratorConfig::complete("my_workflow");
+        let result = convert_to_rust_with_config(json, &config).unwrap();
+        assert!(result.contains("pub fn my_workflow()"));
+        assert!(result.contains("use rucomfyui::"));
+    }
+}

--- a/crates/rucomfyui_workflow_converter/src/workflow_analyzer.rs
+++ b/crates/rucomfyui_workflow_converter/src/workflow_analyzer.rs
@@ -1,0 +1,275 @@
+//! Workflow analysis and topological sorting.
+
+use rucomfyui::workflow::{Workflow, WorkflowInput, WorkflowNodeId};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+
+use crate::{ConversionError, Result};
+
+/// An analyzed workflow with nodes in topological order.
+#[derive(Debug, Clone)]
+pub struct AnalyzedWorkflow {
+    /// Nodes in topological order (dependencies first, outputs last).
+    pub nodes: Vec<AnalyzedNode>,
+    /// Map from original node ID to generated variable name.
+    pub node_var_names: HashMap<WorkflowNodeId, String>,
+}
+
+/// An analyzed node with its dependencies resolved.
+#[derive(Debug, Clone)]
+pub struct AnalyzedNode {
+    /// The original node ID.
+    pub id: WorkflowNodeId,
+    /// The class type of the node (e.g., "CheckpointLoaderSimple").
+    pub class_type: String,
+    /// Display name from metadata, if available.
+    pub display_name: Option<String>,
+    /// Inputs with their values or references to other nodes (sorted by key for deterministic output).
+    pub inputs: BTreeMap<String, AnalyzedInput>,
+    /// The variable name to use for this node in generated code.
+    pub var_name: String,
+}
+
+/// An analyzed input value.
+#[derive(Debug, Clone)]
+pub enum AnalyzedInput {
+    /// A literal string value.
+    String(String),
+    /// A literal integer value.
+    Integer(i64),
+    /// A literal float value.
+    Float(f64),
+    /// A literal boolean value.
+    Boolean(bool),
+    /// A reference to another node's output.
+    NodeRef {
+        /// The variable name of the referenced node.
+        var_name: String,
+        /// The output slot index.
+        slot: u32,
+    },
+}
+
+impl AnalyzedWorkflow {
+    /// Analyze a workflow from JSON string.
+    pub fn from_json(json: &str) -> Result<Self> {
+        let workflow: Workflow = serde_json::from_str(json)?;
+        Self::from_workflow(&workflow)
+    }
+
+    /// Analyze a workflow.
+    pub fn from_workflow(workflow: &Workflow) -> Result<Self> {
+        let sorted_ids = topological_sort(workflow)?;
+
+        // Generate variable names for each node
+        let mut node_var_names = HashMap::new();
+        let mut name_counts: HashMap<String, usize> = HashMap::new();
+
+        for &id in &sorted_ids {
+            let node = workflow
+                .0
+                .get(&id)
+                .ok_or_else(|| ConversionError::NodeNotFound(id.to_string()))?;
+
+            let base_name = class_type_to_var_name(&node.class_type);
+            let count = name_counts.entry(base_name.clone()).or_insert(0);
+            let var_name = if *count == 0 {
+                base_name.clone()
+            } else {
+                format!("{}_{}", base_name, count)
+            };
+            *count += 1;
+            node_var_names.insert(id, var_name);
+        }
+
+        // Build analyzed nodes
+        let mut nodes = Vec::new();
+        for id in sorted_ids {
+            let node = workflow
+                .0
+                .get(&id)
+                .ok_or_else(|| ConversionError::NodeNotFound(id.to_string()))?;
+
+            let var_name = node_var_names.get(&id).unwrap().clone();
+            let display_name = node.meta.as_ref().map(|m| m.title().to_string());
+
+            let mut inputs = BTreeMap::new();
+            for (name, input) in &node.inputs {
+                let analyzed = match input {
+                    WorkflowInput::String(s) => AnalyzedInput::String(s.clone()),
+                    WorkflowInput::F64(f) => AnalyzedInput::Float(*f),
+                    WorkflowInput::I64(i) => AnalyzedInput::Integer(*i),
+                    WorkflowInput::U64(u) => AnalyzedInput::Integer(*u as i64),
+                    WorkflowInput::Boolean(b) => AnalyzedInput::Boolean(*b),
+                    WorkflowInput::Slot(node_id_str, slot) => {
+                        let ref_id: WorkflowNodeId = node_id_str.parse().map_err(|_| {
+                            ConversionError::InvalidNodeReference(node_id_str.clone())
+                        })?;
+                        let ref_var_name = node_var_names.get(&ref_id).ok_or_else(|| {
+                            ConversionError::InvalidNodeReference(node_id_str.clone())
+                        })?;
+                        AnalyzedInput::NodeRef {
+                            var_name: ref_var_name.clone(),
+                            slot: *slot,
+                        }
+                    }
+                };
+                inputs.insert(name.clone(), analyzed);
+            }
+
+            nodes.push(AnalyzedNode {
+                id,
+                class_type: node.class_type.clone(),
+                display_name,
+                inputs,
+                var_name,
+            });
+        }
+
+        Ok(AnalyzedWorkflow {
+            nodes,
+            node_var_names,
+        })
+    }
+}
+
+/// Convert a class type like "CheckpointLoaderSimple" to a variable name like "checkpoint_loader_simple".
+fn class_type_to_var_name(class_type: &str) -> String {
+    use convert_case::{Case, Casing};
+
+    // Handle special characters
+    let cleaned = class_type
+        .replace(".", "_")
+        .replace("|", "_")
+        .replace(" ", "_");
+
+    // Convert to snake_case
+    cleaned.to_case(Case::Snake)
+}
+
+/// Perform topological sort on the workflow graph.
+/// Returns nodes in dependency order (nodes with no dependencies first).
+fn topological_sort(workflow: &Workflow) -> Result<Vec<WorkflowNodeId>> {
+    let mut in_degree: HashMap<WorkflowNodeId, usize> = HashMap::new();
+    let mut dependents: HashMap<WorkflowNodeId, Vec<WorkflowNodeId>> = HashMap::new();
+
+    // Initialize in_degree for all nodes
+    for &node_id in workflow.0.keys() {
+        in_degree.entry(node_id).or_insert(0);
+        dependents.entry(node_id).or_default();
+    }
+
+    // Calculate in-degrees and dependencies
+    for (&node_id, node) in &workflow.0 {
+        for input in node.inputs.values() {
+            if let WorkflowInput::Slot(dep_id_str, _) = input {
+                if let Ok(dep_id) = dep_id_str.parse::<u32>() {
+                    let dep_node_id = WorkflowNodeId(dep_id);
+                    if workflow.0.contains_key(&dep_node_id) {
+                        *in_degree.entry(node_id).or_insert(0) += 1;
+                        dependents.entry(dep_node_id).or_default().push(node_id);
+                    }
+                }
+            }
+        }
+    }
+
+    // Kahn's algorithm for topological sort
+    let mut queue: VecDeque<WorkflowNodeId> = in_degree
+        .iter()
+        .filter(|(_, &degree)| degree == 0)
+        .map(|(&id, _)| id)
+        .collect();
+
+    // Sort queue for deterministic output
+    let mut queue_vec: Vec<_> = queue.drain(..).collect();
+    queue_vec.sort_by_key(|id| id.0);
+    queue = queue_vec.into_iter().collect();
+
+    let mut result = Vec::new();
+    let mut visited = HashSet::new();
+
+    while let Some(node_id) = queue.pop_front() {
+        if visited.contains(&node_id) {
+            continue;
+        }
+        visited.insert(node_id);
+        result.push(node_id);
+
+        // Get dependents and sort them for deterministic output
+        if let Some(deps) = dependents.get(&node_id) {
+            let mut sorted_deps = deps.to_vec();
+            sorted_deps.sort_by_key(|id| id.0);
+
+            for dependent in sorted_deps {
+                if let Some(degree) = in_degree.get_mut(&dependent) {
+                    *degree = degree.saturating_sub(1);
+                    if *degree == 0 && !visited.contains(&dependent) {
+                        queue.push_back(dependent);
+                    }
+                }
+            }
+        }
+    }
+
+    // Check if all nodes were visited (no cycles)
+    if result.len() != workflow.0.len() {
+        return Err(ConversionError::CyclicWorkflow);
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_class_type_to_var_name() {
+        assert_eq!(
+            class_type_to_var_name("CheckpointLoaderSimple"),
+            "checkpoint_loader_simple"
+        );
+        assert_eq!(class_type_to_var_name("KSampler"), "k_sampler");
+        assert_eq!(class_type_to_var_name("VAEDecode"), "vae_decode");
+        assert_eq!(class_type_to_var_name("CLIPTextEncode"), "clip_text_encode");
+    }
+
+    #[test]
+    fn test_simple_workflow_analysis() {
+        let json = r#"{
+            "1": {
+                "inputs": { "ckpt_name": "model.safetensors" },
+                "class_type": "CheckpointLoaderSimple"
+            },
+            "2": {
+                "inputs": {
+                    "seed": 0,
+                    "steps": 20,
+                    "model": ["1", 0]
+                },
+                "class_type": "KSampler"
+            }
+        }"#;
+
+        let analyzed = AnalyzedWorkflow::from_json(json).unwrap();
+        assert_eq!(analyzed.nodes.len(), 2);
+
+        // First node should be CheckpointLoaderSimple (no dependencies)
+        assert_eq!(analyzed.nodes[0].class_type, "CheckpointLoaderSimple");
+        assert_eq!(analyzed.nodes[0].var_name, "checkpoint_loader_simple");
+
+        // Second node should be KSampler (depends on first)
+        assert_eq!(analyzed.nodes[1].class_type, "KSampler");
+        assert_eq!(analyzed.nodes[1].var_name, "k_sampler");
+
+        // Check that KSampler references the checkpoint loader
+        if let Some(AnalyzedInput::NodeRef { var_name, slot }) =
+            analyzed.nodes[1].inputs.get("model")
+        {
+            assert_eq!(var_name, "checkpoint_loader_simple");
+            assert_eq!(*slot, 0);
+        } else {
+            panic!("Expected NodeRef for model input");
+        }
+    }
+}

--- a/crates/rucomfyui_workflow_converter/testdata/example_workflow.json
+++ b/crates/rucomfyui_workflow_converter/testdata/example_workflow.json
@@ -1,0 +1,63 @@
+{
+    "1": {
+        "inputs": { "ckpt_name": "model.safetensors" },
+        "class_type": "CheckpointLoaderSimple",
+        "_meta": { "title": "Load Checkpoint" }
+    },
+    "2": {
+        "inputs": {
+            "text": "a beautiful landscape",
+            "clip": ["1", 1]
+        },
+        "class_type": "CLIPTextEncode",
+        "_meta": { "title": "Positive Prompt" }
+    },
+    "3": {
+        "inputs": {
+            "text": "ugly, blurry",
+            "clip": ["1", 1]
+        },
+        "class_type": "CLIPTextEncode",
+        "_meta": { "title": "Negative Prompt" }
+    },
+    "4": {
+        "inputs": {
+            "width": 1024,
+            "height": 1024,
+            "batch_size": 1
+        },
+        "class_type": "EmptyLatentImage",
+        "_meta": { "title": "Empty Latent" }
+    },
+    "5": {
+        "inputs": {
+            "model": ["1", 0],
+            "seed": 42,
+            "steps": 20,
+            "cfg": 7.5,
+            "sampler_name": "euler",
+            "scheduler": "normal",
+            "positive": ["2", 0],
+            "negative": ["3", 0],
+            "latent_image": ["4", 0],
+            "denoise": 1.0
+        },
+        "class_type": "KSampler",
+        "_meta": { "title": "Sampler" }
+    },
+    "6": {
+        "inputs": {
+            "samples": ["5", 0],
+            "vae": ["1", 2]
+        },
+        "class_type": "VAEDecode",
+        "_meta": { "title": "VAE Decode" }
+    },
+    "7": {
+        "inputs": {
+            "images": ["6", 0]
+        },
+        "class_type": "PreviewImage",
+        "_meta": { "title": "Preview" }
+    }
+}

--- a/crates/rucomfyui_workflow_converter/testdata/simple_workflow.json
+++ b/crates/rucomfyui_workflow_converter/testdata/simple_workflow.json
@@ -1,0 +1,6 @@
+{
+    "1": {
+        "inputs": { "ckpt_name": "model.safetensors" },
+        "class_type": "CheckpointLoaderSimple"
+    }
+}

--- a/crates/rucomfyui_workflow_converter/tests/lua_generation.rs
+++ b/crates/rucomfyui_workflow_converter/tests/lua_generation.rs
@@ -59,24 +59,24 @@ fn dedent(code: &str) -> String {
         .to_string()
 }
 
-/// Parse Lua code and return a normalized string for comparison.
-fn normalize_lua(code: &str) -> String {
+/// Parse Lua code and return the AST.
+fn parse_lua(code: &str) -> full_moon::ast::Ast {
     let dedented = dedent(code);
-    let ast = full_moon::parse(&dedented).expect("Failed to parse Lua code");
-    ast.to_string().trim().to_string()
+    full_moon::parse(&dedented).expect("Failed to parse Lua code")
 }
 
-/// Assert that two Lua code strings parse to equivalent ASTs.
+/// Assert that two Lua code strings parse to semantically similar ASTs.
 fn assert_lua_eq(actual: &str, expected: &str) {
-    let actual_normalized = normalize_lua(actual);
-    let expected_normalized = normalize_lua(expected);
+    use full_moon::node::Node;
 
-    assert_eq!(
-        actual_normalized,
-        expected_normalized,
-        "\n\nActual (normalized):\n{}\n\nExpected (normalized):\n{}",
-        actual_normalized,
-        expected_normalized
+    let actual_ast = parse_lua(actual);
+    let expected_ast = parse_lua(expected);
+
+    assert!(
+        actual_ast.nodes().similar(expected_ast.nodes()),
+        "\n\nActual:\n{}\n\nExpected:\n{}",
+        actual_ast,
+        expected_ast
     );
 }
 

--- a/crates/rucomfyui_workflow_converter/tests/lua_generation.rs
+++ b/crates/rucomfyui_workflow_converter/tests/lua_generation.rs
@@ -2,6 +2,8 @@
 //!
 //! These tests verify the output of the Lua generator.
 
+#![cfg(feature = "lua")]
+
 use rucomfyui_workflow_converter::{
     convert_to_lua, convert_to_lua_with_config, LuaGeneratorConfig,
 };

--- a/crates/rucomfyui_workflow_converter/tests/lua_generation.rs
+++ b/crates/rucomfyui_workflow_converter/tests/lua_generation.rs
@@ -1,0 +1,224 @@
+//! Tests for Lua code generation.
+//!
+//! These tests verify the output of the Lua generator.
+
+use rucomfyui_workflow_converter::{
+    convert_to_lua, convert_to_lua_with_config, LuaGeneratorConfig,
+};
+use std::collections::HashSet;
+
+fn extract_lua_lines(code: &str) -> HashSet<String> {
+    code.lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty() && !l.starts_with("--"))
+        .collect()
+}
+
+#[test]
+fn test_simple_checkpoint_loader() {
+    let workflow = r#"{
+        "1": {
+            "inputs": { "ckpt_name": "model.safetensors" },
+            "class_type": "CheckpointLoaderSimple"
+        }
+    }"#;
+
+    let code = convert_to_lua(workflow).expect("Conversion failed");
+    assert_eq!(
+        code.trim(),
+        r#"local checkpoint_loader_simple = g:CheckpointLoaderSimple("model.safetensors")"#
+    );
+}
+
+#[test]
+fn test_clip_text_encode_with_reference() {
+    let workflow = r#"{
+        "1": {
+            "inputs": { "ckpt_name": "model.safetensors" },
+            "class_type": "CheckpointLoaderSimple"
+        },
+        "2": {
+            "inputs": {
+                "text": "a cat",
+                "clip": ["1", 1]
+            },
+            "class_type": "CLIPTextEncode"
+        }
+    }"#;
+
+    let code = convert_to_lua(workflow).expect("Conversion failed");
+    let lines = extract_lua_lines(&code);
+
+    // Check checkpoint loader
+    assert!(lines.contains(
+        r#"local checkpoint_loader_simple = g:CheckpointLoaderSimple("model.safetensors")"#
+    ));
+
+    // Check CLIPTextEncode
+    assert!(lines.contains("local clip_text_encode = g:CLIPTextEncode {"));
+    assert!(lines.contains(r#"text = "a cat","#));
+    assert!(lines.contains("clip = checkpoint_loader_simple.clip,"));
+    assert!(lines.contains("}"));
+}
+
+#[test]
+fn test_empty_latent_image() {
+    let workflow = r#"{
+        "1": {
+            "inputs": {
+                "width": 1024,
+                "height": 1024,
+                "batch_size": 1
+            },
+            "class_type": "EmptyLatentImage"
+        }
+    }"#;
+
+    let code = convert_to_lua(workflow).expect("Conversion failed");
+    let lines = extract_lua_lines(&code);
+
+    assert!(lines.contains("local empty_latent_image = g:EmptyLatentImage {"));
+    assert!(lines.contains("width = 1024.0,"));
+    assert!(lines.contains("height = 1024.0,"));
+    assert!(lines.contains("batch_size = 1.0,"));
+    assert!(lines.contains("}"));
+}
+
+#[test]
+fn test_ksampler() {
+    let workflow = r#"{
+        "1": {
+            "inputs": { "ckpt_name": "model.safetensors" },
+            "class_type": "CheckpointLoaderSimple"
+        },
+        "2": {
+            "inputs": { "width": 512, "height": 512, "batch_size": 1 },
+            "class_type": "EmptyLatentImage"
+        },
+        "3": {
+            "inputs": { "text": "a cat", "clip": ["1", 1] },
+            "class_type": "CLIPTextEncode"
+        },
+        "4": {
+            "inputs": {
+                "model": ["1", 0],
+                "seed": 0,
+                "steps": 20,
+                "cfg": 8.0,
+                "sampler_name": "euler",
+                "scheduler": "normal",
+                "positive": ["3", 0],
+                "negative": ["3", 0],
+                "latent_image": ["2", 0],
+                "denoise": 1.0
+            },
+            "class_type": "KSampler"
+        }
+    }"#;
+
+    let code = convert_to_lua(workflow).expect("Conversion failed");
+    let lines = extract_lua_lines(&code);
+
+    // Verify the structure
+    assert!(lines.contains(
+        r#"local checkpoint_loader_simple = g:CheckpointLoaderSimple("model.safetensors")"#
+    ));
+    assert!(lines.contains("local empty_latent_image = g:EmptyLatentImage {"));
+    assert!(lines.contains("local clip_text_encode = g:CLIPTextEncode {"));
+    assert!(lines.contains("local k_sampler = g:KSampler {"));
+
+    // Verify references
+    assert!(lines.contains("model = checkpoint_loader_simple.model,"));
+    assert!(lines.contains("latent_image = empty_latent_image,"));
+    assert!(lines.contains("positive = clip_text_encode,"));
+}
+
+#[test]
+fn test_complete_workflow_with_boilerplate() {
+    let workflow = r#"{
+        "1": {
+            "inputs": { "ckpt_name": "model.safetensors" },
+            "class_type": "CheckpointLoaderSimple"
+        },
+        "2": {
+            "inputs": { "images": ["1", 0] },
+            "class_type": "PreviewImage"
+        }
+    }"#;
+
+    let config = LuaGeneratorConfig::complete();
+    let code = convert_to_lua_with_config(workflow, &config).expect("Conversion failed");
+
+    // Check boilerplate lines
+    assert!(code.contains("local object_info = client:get_object_info()"));
+    assert!(code.contains("local g = comfy.graph(object_info)"));
+
+    // Check execution
+    assert!(code.contains("local result = client:easy_queue(g)"));
+    assert!(code.contains("return result[preview_image]"));
+}
+
+#[test]
+fn test_string_with_quotes() {
+    // The JSON parser will unescape the string, so we use escaped quotes in JSON
+    let workflow = r#"{
+        "1": {
+            "inputs": { "text": "a \"quoted\" string" },
+            "class_type": "CLIPTextEncode"
+        }
+    }"#;
+
+    let code = convert_to_lua(workflow).expect("Conversion failed");
+    // The Lua generator should escape the quotes
+    assert!(
+        code.contains(r#"\"quoted\""#),
+        "Code should contain escaped quotes: {}",
+        code
+    );
+}
+
+#[test]
+fn test_multi_output_node_references() {
+    let workflow = r#"{
+        "1": {
+            "inputs": { "ckpt_name": "model.safetensors" },
+            "class_type": "CheckpointLoaderSimple"
+        },
+        "2": {
+            "inputs": { "samples": ["1", 0], "vae": ["1", 2] },
+            "class_type": "VAEDecode"
+        }
+    }"#;
+
+    let code = convert_to_lua(workflow).expect("Conversion failed");
+    let lines = extract_lua_lines(&code);
+
+    // Model is slot 0, VAE is slot 2
+    // Since CheckpointLoaderSimple has multiple outputs, we should use named fields
+    assert!(lines.contains("samples = checkpoint_loader_simple.model,"));
+    assert!(lines.contains("vae = checkpoint_loader_simple.vae,"));
+}
+
+#[test]
+fn test_variable_naming() {
+    let workflow = r#"{
+        "1": {
+            "inputs": { "ckpt_name": "model.safetensors" },
+            "class_type": "CheckpointLoaderSimple"
+        },
+        "2": {
+            "inputs": { "text": "first", "clip": ["1", 1] },
+            "class_type": "CLIPTextEncode"
+        },
+        "3": {
+            "inputs": { "text": "second", "clip": ["1", 1] },
+            "class_type": "CLIPTextEncode"
+        }
+    }"#;
+
+    let code = convert_to_lua(workflow).expect("Conversion failed");
+
+    // Should have two different variable names for the two CLIPTextEncode nodes
+    assert!(code.contains("local clip_text_encode = g:CLIPTextEncode"));
+    assert!(code.contains("local clip_text_encode_1 = g:CLIPTextEncode"));
+}

--- a/crates/rucomfyui_workflow_converter/tests/rust_compilation.rs
+++ b/crates/rucomfyui_workflow_converter/tests/rust_compilation.rs
@@ -3,6 +3,8 @@
 //! These tests convert workflow JSON to Rust code and then verify the code
 //! compiles by creating a temporary crate and running `cargo check`.
 
+#![cfg(feature = "rust")]
+
 use rucomfyui::object_info::ObjectInfo;
 use rucomfyui_workflow_converter::{convert_to_rust_with_object_info, RustGeneratorConfig};
 use std::fs;

--- a/crates/rucomfyui_workflow_converter/tests/rust_compilation.rs
+++ b/crates/rucomfyui_workflow_converter/tests/rust_compilation.rs
@@ -52,78 +52,11 @@ pub fn {function_name}() -> (Workflow, WorkflowNodeId) {{
     )
 }
 
-/// Example workflow JSON for testing.
-const EXAMPLE_WORKFLOW: &str = r#"{
-    "1": {
-        "inputs": { "ckpt_name": "model.safetensors" },
-        "class_type": "CheckpointLoaderSimple",
-        "_meta": { "title": "Load Checkpoint" }
-    },
-    "2": {
-        "inputs": {
-            "text": "a beautiful landscape",
-            "clip": ["1", 1]
-        },
-        "class_type": "CLIPTextEncode",
-        "_meta": { "title": "Positive Prompt" }
-    },
-    "3": {
-        "inputs": {
-            "text": "ugly, blurry",
-            "clip": ["1", 1]
-        },
-        "class_type": "CLIPTextEncode",
-        "_meta": { "title": "Negative Prompt" }
-    },
-    "4": {
-        "inputs": {
-            "width": 1024,
-            "height": 1024,
-            "batch_size": 1
-        },
-        "class_type": "EmptyLatentImage",
-        "_meta": { "title": "Empty Latent" }
-    },
-    "5": {
-        "inputs": {
-            "model": ["1", 0],
-            "seed": 42,
-            "steps": 20,
-            "cfg": 7.5,
-            "sampler_name": "euler",
-            "scheduler": "normal",
-            "positive": ["2", 0],
-            "negative": ["3", 0],
-            "latent_image": ["4", 0],
-            "denoise": 1.0
-        },
-        "class_type": "KSampler",
-        "_meta": { "title": "Sampler" }
-    },
-    "6": {
-        "inputs": {
-            "samples": ["5", 0],
-            "vae": ["1", 2]
-        },
-        "class_type": "VAEDecode",
-        "_meta": { "title": "VAE Decode" }
-    },
-    "7": {
-        "inputs": {
-            "images": ["6", 0]
-        },
-        "class_type": "PreviewImage",
-        "_meta": { "title": "Preview" }
-    }
-}"#;
+/// Example workflow JSON for testing (loaded from testdata/).
+const EXAMPLE_WORKFLOW: &str = include_str!("../testdata/example_workflow.json");
 
 /// Simple workflow with just a checkpoint loader.
-const SIMPLE_WORKFLOW: &str = r#"{
-    "1": {
-        "inputs": { "ckpt_name": "model.safetensors" },
-        "class_type": "CheckpointLoaderSimple"
-    }
-}"#;
+const SIMPLE_WORKFLOW: &str = include_str!("../testdata/simple_workflow.json");
 
 fn create_test_crate(code: &str) -> tempfile::TempDir {
     let temp_dir = tempfile::tempdir().expect("Failed to create temp directory");

--- a/crates/rucomfyui_workflow_converter/tests/rust_compilation.rs
+++ b/crates/rucomfyui_workflow_converter/tests/rust_compilation.rs
@@ -1,0 +1,211 @@
+//! Integration tests that verify generated Rust code compiles correctly.
+//!
+//! These tests convert workflow JSON to Rust code and then verify the code
+//! compiles by creating a temporary crate and running `cargo check`.
+
+use rucomfyui::object_info::ObjectInfo;
+use rucomfyui_workflow_converter::{convert_to_rust_with_object_info, RustGeneratorConfig};
+use std::fs;
+use std::process::Command;
+
+/// Load the ObjectInfo from the generate_nodes crate.
+fn load_object_info() -> ObjectInfo {
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let object_info_path = manifest_dir
+        .parent()
+        .unwrap()
+        .join("rucomfyui")
+        .join("generate_nodes")
+        .join("object_info.json");
+
+    let json = fs::read_to_string(&object_info_path).unwrap_or_else(|e| {
+        panic!(
+            "Failed to read object_info.json from {:?}: {}",
+            object_info_path, e
+        )
+    });
+
+    let objects: Vec<rucomfyui::object_info::Object> =
+        serde_json::from_str(&json).expect("Failed to parse object_info.json");
+
+    objects.into_iter().map(|o| (o.name.clone(), o)).collect()
+}
+
+/// Example workflow JSON for testing.
+const EXAMPLE_WORKFLOW: &str = r#"{
+    "1": {
+        "inputs": { "ckpt_name": "model.safetensors" },
+        "class_type": "CheckpointLoaderSimple",
+        "_meta": { "title": "Load Checkpoint" }
+    },
+    "2": {
+        "inputs": {
+            "text": "a beautiful landscape",
+            "clip": ["1", 1]
+        },
+        "class_type": "CLIPTextEncode",
+        "_meta": { "title": "Positive Prompt" }
+    },
+    "3": {
+        "inputs": {
+            "text": "ugly, blurry",
+            "clip": ["1", 1]
+        },
+        "class_type": "CLIPTextEncode",
+        "_meta": { "title": "Negative Prompt" }
+    },
+    "4": {
+        "inputs": {
+            "width": 1024,
+            "height": 1024,
+            "batch_size": 1
+        },
+        "class_type": "EmptyLatentImage",
+        "_meta": { "title": "Empty Latent" }
+    },
+    "5": {
+        "inputs": {
+            "model": ["1", 0],
+            "seed": 42,
+            "steps": 20,
+            "cfg": 7.5,
+            "sampler_name": "euler",
+            "scheduler": "normal",
+            "positive": ["2", 0],
+            "negative": ["3", 0],
+            "latent_image": ["4", 0],
+            "denoise": 1.0
+        },
+        "class_type": "KSampler",
+        "_meta": { "title": "Sampler" }
+    },
+    "6": {
+        "inputs": {
+            "samples": ["5", 0],
+            "vae": ["1", 2]
+        },
+        "class_type": "VAEDecode",
+        "_meta": { "title": "VAE Decode" }
+    },
+    "7": {
+        "inputs": {
+            "images": ["6", 0]
+        },
+        "class_type": "PreviewImage",
+        "_meta": { "title": "Preview" }
+    }
+}"#;
+
+/// Simple workflow with just a checkpoint loader.
+const SIMPLE_WORKFLOW: &str = r#"{
+    "1": {
+        "inputs": { "ckpt_name": "model.safetensors" },
+        "class_type": "CheckpointLoaderSimple"
+    }
+}"#;
+
+fn create_test_crate(code: &str) -> tempfile::TempDir {
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp directory");
+    let src_dir = temp_dir.path().join("src");
+    fs::create_dir_all(&src_dir).expect("Failed to create src directory");
+
+    // Get the path to rucomfyui crate relative to this test's manifest
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let rucomfyui_path = manifest_dir.parent().unwrap().join("rucomfyui");
+
+    // Write Cargo.toml
+    let cargo_toml = format!(
+        r#"[package]
+name = "test_workflow"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rucomfyui = {{ path = "{}" }}
+"#,
+        rucomfyui_path.display()
+    );
+    fs::write(temp_dir.path().join("Cargo.toml"), cargo_toml).expect("Failed to write Cargo.toml");
+
+    // Write lib.rs
+    fs::write(src_dir.join("lib.rs"), code).expect("Failed to write lib.rs");
+
+    temp_dir
+}
+
+fn check_compiles(temp_dir: &tempfile::TempDir) -> Result<(), String> {
+    let output = Command::new("cargo")
+        .arg("check")
+        .current_dir(temp_dir.path())
+        .output()
+        .expect("Failed to run cargo check");
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "Compilation failed:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        ))
+    }
+}
+
+#[test]
+fn test_example_workflow_compiles() {
+    let object_info = load_object_info();
+    let config = RustGeneratorConfig::complete("example_workflow");
+    let code = convert_to_rust_with_object_info(EXAMPLE_WORKFLOW, &object_info, &config)
+        .expect("Conversion failed");
+
+    // Verify it contains expected elements
+    assert!(code.contains("pub fn example_workflow()"));
+    assert!(code.contains("CheckpointLoaderSimple"));
+    assert!(code.contains("CLIPTextEncode"));
+    assert!(code.contains("EmptyLatentImage"));
+    assert!(code.contains("KSampler"));
+    assert!(code.contains("VAEDecode"));
+    assert!(code.contains("PreviewImage"));
+
+    // Actually compile the code
+    let temp_dir = create_test_crate(&code);
+    check_compiles(&temp_dir).expect("Generated code should compile");
+}
+
+#[test]
+fn test_simple_workflow_compiles() {
+    let object_info = load_object_info();
+    let config = RustGeneratorConfig::complete("simple_workflow");
+    let code = convert_to_rust_with_object_info(SIMPLE_WORKFLOW, &object_info, &config)
+        .expect("Conversion failed");
+
+    // Actually compile the code
+    let temp_dir = create_test_crate(&code);
+    check_compiles(&temp_dir).expect("Generated code should compile");
+}
+
+#[test]
+fn test_existing_workflow_file_compiles() {
+    let object_info = load_object_info();
+    // Test with the actual example workflow file from rucomfyui
+    let workflow_json = include_str!("../../rucomfyui/examples/existing_workflow.json");
+    let config = RustGeneratorConfig::complete("existing_workflow");
+    let code = convert_to_rust_with_object_info(workflow_json, &object_info, &config)
+        .expect("Conversion failed");
+
+    let temp_dir = create_test_crate(&code);
+    check_compiles(&temp_dir).expect("Generated code should compile");
+}
+
+#[test]
+fn test_snippet_mode_generates_valid_code() {
+    let object_info = load_object_info();
+    let config = RustGeneratorConfig::snippet();
+    let code = convert_to_rust_with_object_info(SIMPLE_WORKFLOW, &object_info, &config)
+        .expect("Conversion failed");
+
+    // Should not contain function wrapper
+    assert!(!code.contains("pub fn"));
+    // Should contain the workflow construction
+    assert!(code.contains("let g = WorkflowGraph::new()"));
+}


### PR DESCRIPTION
Fixes #7.

Implements a library and CLI tool to convert ComfyUI API workflow JSON to:
- Typed Rust code using the `nodes` module with ObjectInfo support
- Lua code compatible with `rucomfyui_mlua`

Key features:
- Topological sorting for proper node ordering
- Type-aware code generation using ObjectInfo
- Support for multi-output node references
- Deterministic output using BTreeMap
- Uses quote/prettyplease for Rust code formatting

Includes comprehensive tests:
- Rust compilation tests that verify generated code compiles
- Lua generation tests for various workflow patterns